### PR TITLE
Recent枠表示機能(β)とデータ提供機能の組み込み

### DIFF
--- a/chunithm.js
+++ b/chunithm.js
@@ -630,7 +630,7 @@ $("#cra_wrapper").delay(400).fadeIn(400);
 // Create playlog entity if music_info exists. Otherwise return null.
 function playlog(id, level, score, play_date /* optional */) {
     var info = music_info[id];
-    var rate_base  = info && info.rate_base[id];
+    var rate_base  = info && info.rate_base[level];
     if (!rate_base) return null;
     return {
         id:        id,
@@ -663,7 +663,7 @@ function push_playlog_to_recent_candidates (log) {
     if (log.rate > min_rate) {
         for (var k = 0; k < recent_candidates.length; k++) {
             if (recent_candidates[k].rate < log.rate) {
-                if (playlog.length >= 30) recent_candidates.splice(k, 1);
+                if (recent_candidates.length >= 30) recent_candidates.splice(k, 1);
                 recent_candidates.push(log);
                 break;
             }
@@ -671,7 +671,7 @@ function push_playlog_to_recent_candidates (log) {
     }
 
     else if (log.score < 1007500 && log.score < min_score) {
-        if (log.length >= 30) recent_candidates.shift();
+        if (recent_candidates.length >= 30) recent_candidates.shift();
         recent_candidates.push(log);
     }
 }

--- a/chunithm.js
+++ b/chunithm.js
@@ -1059,9 +1059,9 @@ function rate_display()
     last_best_list = last_best_list && last_best_list.sort(comp_id);
     for (var i = 0, j = 0; i < best_list.length;) {
         if (!last_best_list[j]) break;
-        var comp = comp_rate(best_list[i], last_best_list[j]);
-        if (comp < 0) j++;
-        else if (comp > 0) i++;
+        var comp = comp_id(best_list[i], last_best_list[j]);
+        if (comp < 0) i++;
+        else if (comp > 0) j++;
         else {
             best_list[i].rate_diff = best_list[i].rate - last_best_list[j].rate;
             i++;

--- a/chunithm.js
+++ b/chunithm.js
@@ -661,23 +661,23 @@ function fecth_playlog(callback)
         }).slice(0, 10);
     }
 
+    function create_playlog(rate_base, score, play_date, id, name, level, image) {
+        return {
+            id: id,
+            level: level,
+            rate_base: rate_base,
+            image: image,
+            name: name,
+            score: score,
+            rate: score_to_rate(rate_base, score),
+            play_date: play_date
+        };
+    }
+
     $("#cra_window_inner").html("<p>loading playlog ...</p>");
     request_api("GetUserPlaylogApi", {}, function (d) {
+        recent_candidates = last_recent_candidates || Array.apply(null, new (array(30))).map(function (_) { return create_playlog(0, 0, ""); });
         var level_name_map = ["basic", "advance", "expert", "master", "worldsend"];
-
-        recent_candidates = last_recent_candidates;
-        if (!recent_candidates) {
-            recent_candidates = new Array();
-            for (var i = 0; i < 30; i++) {
-                recent_candidates.push({
-                    rate_base: 0,
-                    score: 0,
-                    rate: 0,
-                    play_date: "",
-                });
-            }
-        }
-
         var last_play_date = recent_candidates[recent_candidates.length - 1].play_date;
         for (var i = d.userPlaylogList.length - 1; i >= 0; i--) {
             if (d.userPlaylogList[i].levelName != "expert" && d.userPlaylogList[i].levelName != "master")
@@ -688,16 +688,14 @@ function fecth_playlog(callback)
 
             for (var j = 0; j < chart_list.length; j++) {
                 if (chart_list[j].name == d.userPlaylogList[i].musicName && level_name_map[chart_list[j].level] == d.userPlaylogList[i].levelName) {
-                    var playlog = {
-                        id: chart_list[j].id,
-                        level: chart_list[j].level,
-                        rate_base: chart_list[j].rate_base,
-                        image: chart_list[j].image,
-                        name: chart_list[j].name,
-                        score: d.userPlaylogList[i].score,
-                        rate: score_to_rate(chart_list[j].rate_base, d.userPlaylogList[i].score),
-                        play_date: d.userPlaylogList[i].userPlayDate,
-                    };
+                    var playlog = create_playlog(
+                        chart_list[j].rate_base,
+                        d.userPlaylogList[i].score,
+                        d.userPlaylogList[i].userPlayDate,
+                        chart_list[j].id,
+                        chart_list[j].name,
+                        chart_list[j].level,
+                        chart_list[j].image);
 
                     recent_list = get_recent_list(recent_candidates);
 

--- a/chunithm.js
+++ b/chunithm.js
@@ -1246,35 +1246,7 @@ function rate_display()
         });
 
         $("#cra_offer_playlog").click(function () {
-            try {
-                gas_manage_history(
-                    function (d) {
-                        var data = d.result;
-                        var recent_candidate_list = data.recentCandidate;
-                        alert(recent_candidate_list.map(function (p) {
-                            return p.name + ":(" + p.score + "," + p.rate + ")";
-                        }).reduce(function (prev, curr) {
-                            return prev + "\n" + curr;
-                        }));
-
-                        var recent_list = data.recent;
-                        var ave = recent_list
-                            .map(function (p) { return p.rate; })
-                            .reduce(function (prev, curr) { return prev + curr; }) / 10;
-                        ave = Math.floor(ave * 100) / 100;
-                        alert("Recent値 : " + ave + "\nRecent枠内訳\n" +
-                            recent_list.map(function (p) {
-                                return p.name + ":(" + p.score + "," + p.rate + ")";
-                            }).reduce(function (prev, curr) {
-                                return prev + "\n" + curr;
-                            }));
-                    },
-                    function (id) { alert("エラー : " + id); });
-            }
-            catch (e) {
-                alert("動作が停止しました。次に出てくるアラートメッセージを開発者にお知らせください。");
-                alert("例外 : " + e.name + "\n内容 : " + e.message);
-            }
+            offer_playlog();
         });
 
         // load twitter buttons

--- a/chunithm.js
+++ b/chunithm.js
@@ -660,15 +660,18 @@ function comp_id(p1, p2) {
 function push_playlog_to_recent_candidates (log) {
     var len = recent_candidates.length;
     var recent_list = [].concat(recent_candidates).sort(comp_rate).slice(0, 10);
-    var min_rate    = len ? Math.min.apply(null, recent_list.map(function (p) { return p.rate; })) : 0;
-    var min_score   = len ? Math.min.apply(null, recent_list.map(function (p) { return p.score; })) : 0;
+    var min_rate    = len >= 30 ? Math.min.apply(null, recent_list.map(function (p) { return p.rate; })) : 0;
+    var min_score   = len >= 30 ? Math.min.apply(null, recent_list.map(function (p) { return p.score; })) : 0;
 
     if (log.rate > min_rate) {
-        for (var k = 0; k < recent_candidates.length; k++) {
-            if (recent_candidates[k].rate < log.rate) {
-                if (len >= 30) recent_candidates.splice(k, 1);
-                recent_candidates.push(log);
-                break;
+        if (len < 30) recent_candidates.push(log);
+        else {
+            for (var k = 0; k < recent_candidates.length; k++) {
+                if (recent_candidates[k].rate < log.rate) {
+                    if (len >= 30) recent_candidates.splice(k, 1);
+                    recent_candidates.push(log);
+                    break;
+                }
             }
         }
     }

--- a/chunithm.js
+++ b/chunithm.js
@@ -676,7 +676,7 @@ function fetch_playlog(callback)
 
     $("#cra_window_inner").html("<p>loading playlog ...</p>");
     request_api("GetUserPlaylogApi", {}, function (d) {
-        recent_candidates = last_recent_candidates || Array.apply(null, new (array(30))).map(function (_) { return create_playlog(0, 0, ""); });
+        recent_candidates = last_recent_candidates || Array.apply(null, new Array(30)).map(function (_) { return create_playlog(0, 0, ""); });
         var level_name_map = ["basic", "advance", "expert", "master", "worldsend"];
         var last_play_date = recent_candidates[recent_candidates.length - 1].play_date;
         for (var i = d.userPlaylogList.length - 1; i >= 0; i--) {

--- a/chunithm.js
+++ b/chunithm.js
@@ -698,7 +698,21 @@ function fetch_playlog(callback)
                 d.userPlaylogList[i].score,
                 d.userPlaylogList[i].userPlayDate
             );
-            if (log && (!last_play_date || log.play_date > last_play_date))
+
+            if (!log) {
+                log = {
+                    name: d.userPlaylogList[i].musicName,
+                    image: d.userPlaylogList[i].musicFileName,
+                    level: LEVEL_ID[d.userPlaylogList[i].levelName],
+                    score: d.userPlaylogList[i].score,
+                    rate: 0,
+                    play_date: d.userPlaylogList[i].userPlayDate,
+                    rate_diff: 0,
+                    rate_base: 0,
+                }
+            }
+
+            if ((log.level != 4) && (!last_play_date || log.play_date > last_play_date))
                 push_playlog_to_recent_candidates(log);
         }
         callback();

--- a/chunithm.js
+++ b/chunithm.js
@@ -29,65 +29,65 @@ var DEPENDENCIES = [
 var LEVEL_ID = { basic: 0, advance: 1, expert: 2, master: 3, worldsend: 4 };
 
 var DIFFICULTY = {
-     003: { rate_base: {          3: 11.8 }, image: "img/d739ba44da6798a0.jpg" } // B.B.K.K.B.K.K.
-    ,005: { rate_base: {          3: 11.3 }, image: "img/38faf81803b730f3.jpg" } // Scatman (Ski Ba Bop Ba Dop Bop)
-    ,006: { rate_base: {          3: 12.3 }, image: "img/90589be457544570.jpg" } // Reach for the Stars
-    ,007: { rate_base: { 2: 12.0, 3: 13.6 }, image: "img/b602913a68fca621.jpg" } // 初音ミクの消失
-    ,009: { rate_base: {          3: 11.3 }, image: "img/fce0bad9123dcd76.jpg" } // 情熱大陸
-    ,010: { rate_base: {          3: 11.7 }, image: "img/0d7bd146ebed6fba.jpg" } // All I Want
-    ,014: { rate_base: {          3: 11.0 }, image: "img/af78dd039a36a4c7.jpg" } // コネクト
-    ,017: { rate_base: {          3: 11.1 }, image: "img/696d4f956ebb4209.jpg" } // 空色デイズ
-    ,018: { rate_base: {          3: 11.2 }, image: "img/3c2606abe4dded71.jpg" } // 千本桜
-    ,019: { rate_base: {          3: 13.2 }, image: "img/0b98b8b4e7cfd997.jpg" } // DRAGONLADY
-    ,021: { rate_base: {          3: 11.9 }, image: "img/4f69fb126f579c2f.jpg" } // ナイト・オブ・ナイツ
-    ,023: { rate_base: {          3: 12.1 }, image: "img/b8ab9573859ebe4f.jpg" } // 一触即発☆禅ガール
-    ,027: { rate_base: {          3: 12.5 }, image: "img/fdc3bb451f6403d2.jpg" } // タイガーランペイジ
-    ,033: { rate_base: {          3: 13.0 }, image: "img/fddc37caee47286d.jpg" } // Blue Noise
-    ,035: { rate_base: {          3: 12.4 }, image: "img/aabf49add818546d.jpg" } // Lapis
-    ,036: { rate_base: {          3: 11.0 }, image: "img/e273c9d64170b575.jpg" } // 届かない恋 '13
-    ,037: { rate_base: {          3: 11.3 }, image: "img/335dbb14cedb70bf.jpg" } // 鳥の詩
-    ,038: { rate_base: {          3: 11.0 }, image: "img/529d98ad07709ae5.jpg" } // 天ノ弱
-    ,041: { rate_base: {          3: 11.6 }, image: "img/7f17441bc2582ec8.jpg" } // sweet little sister
-    ,042: { rate_base: {          3: 11.6 }, image: "img/4bbc4ec5ee9aa0b6.jpg" } // oath sign
-    ,045: { rate_base: {          3: 12.2 }, image: "img/90dca26c66c5d5b7.jpg" } // L9
-    ,047: { rate_base: {          3: 12.0 }, image: "img/5cb17a59f4b8c133.jpg" } // 六兆年と一夜物語
-    ,048: { rate_base: {          3: 11.8 }, image: "img/b38eba298df2c6db.jpg" } // Unlimited Spark!
-    ,051: { rate_base: {          3: 12.7 }, image: "img/161f13a787a00032.jpg" } // My First Phone
-    ,052: { rate_base: { 2: 11.1, 3: 13.2 }, image: "img/a62f975edc860e34.jpg" } // Cyberozar
-    ,053: { rate_base: {          3: 12.3 }, image: "img/73ad66e81061bba3.jpg" } // Teriqma
-    ,055: { rate_base: {          3: 11.2 }, image: "img/506f053a80e1b28e.jpg" } // 夏祭り
-    ,056: { rate_base: {          3: 11.0 }, image: "img/2535487ae13b2fd8.jpg" } // そばかす
-    ,060: { rate_base: {          3: 11.3 }, image: "img/3bee1cce7d794f31.jpg" } // only my railgun
-    ,061: { rate_base: { 2: 11.0, 3: 13.5 }, image: "img/2ccf97477eaf45ad.jpg" } // GOLDEN RULE
-    ,062: { rate_base: {          3: 12.4 }, image: "img/9386971505bb20b0.jpg" } // 名も無い鳥
-    ,063: { rate_base: { 2: 11.7, 3: 13.1 }, image: "img/2df15f390356067f.jpg" } // Gate of Fate
-    ,064: { rate_base: {          3: 12.7 }, image: "img/6bf934fede23724d.jpg" } // 今ぞ♡崇め奉れ☆オマエらよ！！～姫の秘メタル渇望～
-    ,065: { rate_base: {          3: 11.1 }, image: "img/713d52aa40ed7fc4.jpg" } // Anemone
-    ,066: { rate_base: {          3: 12.3 }, image: "img/c22702914849a11a.jpg" } // 明るい未来
-    ,067: { rate_base: {          3: 11.2 }, image: "img/11437ebc94947550.jpg" } // 昵懇レファレンス
-    ,068: { rate_base: {          3: 11.7 }, image: "img/145b9b6f4c27d78e.jpg" } // 乗り切れ受験ウォーズ
-    ,069: { rate_base: { 2: 11.9, 3: 13.3 }, image: "img/c2c4ece2034eb620.jpg" } // The wheel to the right
-    ,070: { rate_base: {          3: 12.4 }, image: "img/3ccebd87235f591c.jpg" } // STAR
-    ,071: { rate_base: {          3: 12.3 }, image: "img/2bf02bef3051ecaf.jpg" } // Infantoon Fantasy
-    ,072: { rate_base: {          3: 13.5 }, image: "img/ec3a366b4724f8f6.jpg" } // Genesis
-    ,073: { rate_base: {          3: 12.6 }, image: "img/0c2791f737ce1ff2.jpg" } // MUSIC PЯAYER
-    ,074: { rate_base: {          3: 11.0 }, image: "img/feef37ed3d91cfbd.jpg" } // リリーシア
-    ,075: { rate_base: {          3: 11.7 }, image: "img/e1454dc2eeae2030.jpg" } // Counselor
-    ,076: { rate_base: { 2: 11.8, 3: 13.4 }, image: "img/93abb77776c70b47.jpg" } // luna blu
-    ,077: { rate_base: {          3: 12.8 }, image: "img/01fc7f761272bfb4.jpg" } // ケモノガル
-    ,079: { rate_base: {          3: 11.0 }, image: "img/281f821a06a7da18.jpg" } // ＧＯ！ＧＯ！ラブリズム♥
-    ,082: { rate_base: {          3: 12.5 }, image: "img/27ef71f8a76f1e8a.jpg" } // Memories of Sun and Moon
-    ,083: { rate_base: {          3: 12.2 }, image: "img/181682bf5b277726.jpg" } // ロストワンの号哭
-    ,088: { rate_base: {          3: 12.1 }, image: "img/c4223e68340efa41.jpg" } // The Concept of Love
-    ,090: { rate_base: { 2: 11.6, 3: 13.2 }, image: "img/19d57f9a7652308a.jpg" } // L'épisode
-    ,091: { rate_base: {          3: 11.2 }, image: "img/cb77a66b62023890.jpg" } // Yet Another ”drizzly rain”
-    ,092: { rate_base: {          3: 12.8 }, image: "img/17315fb464f265bd.jpg" } // 最終鬼畜妹・一部声
-    ,093: { rate_base: {          3: 12.3 }, image: "img/6b40809324937ec9.jpg" } // 蒼空に舞え、墨染の桜
-    ,094: { rate_base: {          3: 12.3 }, image: "img/164258c65c714d50.jpg" } // セツナトリップ
-    ,095: { rate_base: {          3: 12.1 }, image: "img/db38c119e4d8933e.jpg" } // 砂漠のハンティングガール♡
-    ,096: { rate_base: {          3: 11.8 }, image: "img/9d2ebc847487e01b.jpg" } // チルノのパーフェクトさんすう教室
-    ,098: { rate_base: {          3: 11.4 }, image: "img/f7e67efaf6ced6ea.jpg" } // 魔理沙は大変なものを盗んでいきました
-    ,099: { rate_base: {          3: 11.7 }, image: "img/ee332e6fa86661fd.jpg" } // 言ノ葉カルマ
+       3: { rate_base: {          3: 11.8 }, image: "img/d739ba44da6798a0.jpg" } // B.B.K.K.B.K.K.
+    ,  5: { rate_base: {          3: 11.3 }, image: "img/38faf81803b730f3.jpg" } // Scatman (Ski Ba Bop Ba Dop Bop)
+    ,  6: { rate_base: {          3: 12.3 }, image: "img/90589be457544570.jpg" } // Reach for the Stars
+    ,  7: { rate_base: { 2: 12.0, 3: 13.6 }, image: "img/b602913a68fca621.jpg" } // 初音ミクの消失
+    ,  9: { rate_base: {          3: 11.3 }, image: "img/fce0bad9123dcd76.jpg" } // 情熱大陸
+    , 10: { rate_base: {          3: 11.7 }, image: "img/0d7bd146ebed6fba.jpg" } // All I Want
+    , 14: { rate_base: {          3: 11.0 }, image: "img/af78dd039a36a4c7.jpg" } // コネクト
+    , 17: { rate_base: {          3: 11.1 }, image: "img/696d4f956ebb4209.jpg" } // 空色デイズ
+    , 18: { rate_base: {          3: 11.2 }, image: "img/3c2606abe4dded71.jpg" } // 千本桜
+    , 19: { rate_base: {          3: 13.2 }, image: "img/0b98b8b4e7cfd997.jpg" } // DRAGONLADY
+    , 21: { rate_base: {          3: 11.9 }, image: "img/4f69fb126f579c2f.jpg" } // ナイト・オブ・ナイツ
+    , 23: { rate_base: {          3: 12.1 }, image: "img/b8ab9573859ebe4f.jpg" } // 一触即発☆禅ガール
+    , 27: { rate_base: {          3: 12.5 }, image: "img/fdc3bb451f6403d2.jpg" } // タイガーランペイジ
+    , 33: { rate_base: {          3: 13.0 }, image: "img/fddc37caee47286d.jpg" } // Blue Noise
+    , 35: { rate_base: {          3: 12.4 }, image: "img/aabf49add818546d.jpg" } // Lapis
+    , 36: { rate_base: {          3: 11.0 }, image: "img/e273c9d64170b575.jpg" } // 届かない恋 '13
+    , 37: { rate_base: {          3: 11.3 }, image: "img/335dbb14cedb70bf.jpg" } // 鳥の詩
+    , 38: { rate_base: {          3: 11.0 }, image: "img/529d98ad07709ae5.jpg" } // 天ノ弱
+    , 41: { rate_base: {          3: 11.6 }, image: "img/7f17441bc2582ec8.jpg" } // sweet little sister
+    , 42: { rate_base: {          3: 11.6 }, image: "img/4bbc4ec5ee9aa0b6.jpg" } // oath sign
+    , 45: { rate_base: {          3: 12.2 }, image: "img/90dca26c66c5d5b7.jpg" } // L9
+    , 47: { rate_base: {          3: 12.0 }, image: "img/5cb17a59f4b8c133.jpg" } // 六兆年と一夜物語
+    , 48: { rate_base: {          3: 11.8 }, image: "img/b38eba298df2c6db.jpg" } // Unlimited Spark!
+    , 51: { rate_base: {          3: 12.7 }, image: "img/161f13a787a00032.jpg" } // My First Phone
+    , 52: { rate_base: { 2: 11.1, 3: 13.2 }, image: "img/a62f975edc860e34.jpg" } // Cyberozar
+    , 53: { rate_base: {          3: 12.3 }, image: "img/73ad66e81061bba3.jpg" } // Teriqma
+    , 55: { rate_base: {          3: 11.2 }, image: "img/506f053a80e1b28e.jpg" } // 夏祭り
+    , 56: { rate_base: {          3: 11.0 }, image: "img/2535487ae13b2fd8.jpg" } // そばかす
+    , 60: { rate_base: {          3: 11.3 }, image: "img/3bee1cce7d794f31.jpg" } // only my railgun
+    , 61: { rate_base: { 2: 11.0, 3: 13.5 }, image: "img/2ccf97477eaf45ad.jpg" } // GOLDEN RULE
+    , 62: { rate_base: {          3: 12.4 }, image: "img/9386971505bb20b0.jpg" } // 名も無い鳥
+    , 63: { rate_base: { 2: 11.7, 3: 13.1 }, image: "img/2df15f390356067f.jpg" } // Gate of Fate
+    , 64: { rate_base: {          3: 12.7 }, image: "img/6bf934fede23724d.jpg" } // 今ぞ♡崇め奉れ☆オマエらよ！！～姫の秘メタル渇望～
+    , 65: { rate_base: {          3: 11.1 }, image: "img/713d52aa40ed7fc4.jpg" } // Anemone
+    , 66: { rate_base: {          3: 12.3 }, image: "img/c22702914849a11a.jpg" } // 明るい未来
+    , 67: { rate_base: {          3: 11.2 }, image: "img/11437ebc94947550.jpg" } // 昵懇レファレンス
+    , 68: { rate_base: {          3: 11.7 }, image: "img/145b9b6f4c27d78e.jpg" } // 乗り切れ受験ウォーズ
+    , 69: { rate_base: { 2: 11.9, 3: 13.3 }, image: "img/c2c4ece2034eb620.jpg" } // The wheel to the right
+    , 70: { rate_base: {          3: 12.4 }, image: "img/3ccebd87235f591c.jpg" } // STAR
+    , 71: { rate_base: {          3: 12.3 }, image: "img/2bf02bef3051ecaf.jpg" } // Infantoon Fantasy
+    , 72: { rate_base: {          3: 13.5 }, image: "img/ec3a366b4724f8f6.jpg" } // Genesis
+    , 73: { rate_base: {          3: 12.6 }, image: "img/0c2791f737ce1ff2.jpg" } // MUSIC PЯAYER
+    , 74: { rate_base: {          3: 11.0 }, image: "img/feef37ed3d91cfbd.jpg" } // リリーシア
+    , 75: { rate_base: {          3: 11.7 }, image: "img/e1454dc2eeae2030.jpg" } // Counselor
+    , 76: { rate_base: { 2: 11.8, 3: 13.4 }, image: "img/93abb77776c70b47.jpg" } // luna blu
+    , 77: { rate_base: {          3: 12.8 }, image: "img/01fc7f761272bfb4.jpg" } // ケモノガル
+    , 79: { rate_base: {          3: 11.0 }, image: "img/281f821a06a7da18.jpg" } // ＧＯ！ＧＯ！ラブリズム♥
+    , 82: { rate_base: {          3: 12.5 }, image: "img/27ef71f8a76f1e8a.jpg" } // Memories of Sun and Moon
+    , 83: { rate_base: {          3: 12.2 }, image: "img/181682bf5b277726.jpg" } // ロストワンの号哭
+    , 88: { rate_base: {          3: 12.1 }, image: "img/c4223e68340efa41.jpg" } // The Concept of Love
+    , 90: { rate_base: { 2: 11.6, 3: 13.2 }, image: "img/19d57f9a7652308a.jpg" } // L'épisode
+    , 91: { rate_base: {          3: 11.2 }, image: "img/cb77a66b62023890.jpg" } // Yet Another ”drizzly rain”
+    , 92: { rate_base: {          3: 12.8 }, image: "img/17315fb464f265bd.jpg" } // 最終鬼畜妹・一部声
+    , 93: { rate_base: {          3: 12.3 }, image: "img/6b40809324937ec9.jpg" } // 蒼空に舞え、墨染の桜
+    , 94: { rate_base: {          3: 12.3 }, image: "img/164258c65c714d50.jpg" } // セツナトリップ
+    , 95: { rate_base: {          3: 12.1 }, image: "img/db38c119e4d8933e.jpg" } // 砂漠のハンティングガール♡
+    , 96: { rate_base: {          3: 11.8 }, image: "img/9d2ebc847487e01b.jpg" } // チルノのパーフェクトさんすう教室
+    , 98: { rate_base: {          3: 11.4 }, image: "img/f7e67efaf6ced6ea.jpg" } // 魔理沙は大変なものを盗んでいきました
+    , 99: { rate_base: {          3: 11.7 }, image: "img/ee332e6fa86661fd.jpg" } // 言ノ葉カルマ
     ,101: { rate_base: {          3: 12.9 }, image: "img/81e347d3b96b2ae1.jpg" } // Tango Rouge
     ,102: { rate_base: {          3: 12.5 }, image: "img/7fc6ae1b488b88de.jpg" } // Tuning Rangers
     ,103: { rate_base: { 2: 11.7, 3: 13.7 }, image: "img/3210d321c2700a57.jpg" } // エンドマークに希望と涙を添えて

--- a/chunithm.js
+++ b/chunithm.js
@@ -1,7 +1,7 @@
 // CHUNITHM Rate Analyzer (C) zk_phi 2015-
 
 // ※ localStorage のデータに互換性がなくなる場合は必ずバージョンを上げる
-var CRA_VERSION = 161224;
+var CRA_VERSION = 170101;
 
 if (!location.href.match(/^https:\/\/chunithm-net.com/)) {
     alert("CHUNITHM NET を開いているタブで実行してください。");

--- a/chunithm.js
+++ b/chunithm.js
@@ -401,23 +401,22 @@ function dom(template, params)
 // global vars
 // -----------------------------------------------------------------------------
 
-// latest rate
+// current values
 var disp_rate         = 0;
 var best_rate         = 0;
 var best_list         = new Array();
 var best_rate_border;
 var recent_rate       = 0;
-var recent_candidates = new Array();
 var opt_rate          = 0;
+var recent_candidates = JSON.parse(localStorage.getItem("cra_recent_candidates")) || new Array();
 
 // load the last data from localStorage (if exists)
-var last_cra_version       = JSON.parse(localStorage.getItem("cra_version"));
-var last_disp_rate         = JSON.parse(localStorage.getItem("cra_disp_rate"));
-var last_best_rate         = JSON.parse(localStorage.getItem("cra_best_rate"));
-var last_best_list         = JSON.parse(localStorage.getItem("cra_best_list"));
-var last_recent_rate       = JSON.parse(localStorage.getItem("cra_recent_rate"));
-var last_recent_candidates = JSON.parse(localStorage.getItem("cra_recent_candidates"));
-var last_opt_rate          = JSON.parse(localStorage.getItem("cra_opt_rate"));
+var last_cra_version = JSON.parse(localStorage.getItem("cra_version"));
+var last_disp_rate   = JSON.parse(localStorage.getItem("cra_disp_rate"));
+var last_best_rate   = JSON.parse(localStorage.getItem("cra_best_rate"));
+var last_best_list   = JSON.parse(localStorage.getItem("cra_best_list"));
+var last_recent_rate = JSON.parse(localStorage.getItem("cra_recent_rate"));
+var last_opt_rate    = JSON.parse(localStorage.getItem("cra_opt_rate"));
 
 // diff between the current rate and the last rate
 var disp_rate_diff;
@@ -615,7 +614,6 @@ if(cra_version == last_cra_version) {
                .click(function() {
                    best_list = last_best_list;
                    disp_rate = last_disp_rate;
-                   recent_candidates = last_recent_candidates;
                    rate_display();
                }));
 }
@@ -656,14 +654,15 @@ function comp_id(p1, p2) {
 
 // push new playlog to recent_candidates if appropriate.
 function push_playlog_to_recent_candidates (log) {
+    var len = recent_candidates.length;
     var recent_list = [].concat(recent_candidates).sort(comp_rate).slice(0, 10);
-    var min_rate    = Math.min.apply(null, recent_list.map(function (p) { return p.rate; }));
-    var min_score   = Math.min.apply(null, recent_list.map(function (p) { return p.score; }));
+    var min_rate    = len ? Math.min.apply(null, recent_list.map(function (p) { return p.rate; })) : 0;
+    var min_score   = len ? Math.min.apply(null, recent_list.map(function (p) { return p.score; })) : 0;
 
     if (log.rate > min_rate) {
         for (var k = 0; k < recent_candidates.length; k++) {
             if (recent_candidates[k].rate < log.rate) {
-                if (recent_candidates.length >= 30) recent_candidates.splice(k, 1);
+                if (len >= 30) recent_candidates.splice(k, 1);
                 recent_candidates.push(log);
                 break;
             }
@@ -671,7 +670,7 @@ function push_playlog_to_recent_candidates (log) {
     }
 
     else if (log.score < 1007500 && log.score < min_score) {
-        if (recent_candidates.length >= 30) recent_candidates.shift();
+        if (len >= 30) recent_candidates.shift();
         recent_candidates.push(log);
     }
 }

--- a/chunithm.js
+++ b/chunithm.js
@@ -407,11 +407,11 @@ var music_info = {};
 // current values
 var disp_rate         = 0;
 var best_rate         = 0;
-var best_list         = new Array();
+var best_list         = [];
 var best_rate_border;
 var recent_rate       = 0;
 var opt_rate          = 0;
-var recent_candidates = JSON.parse(localStorage.getItem("cra_recent_candidates")) || new Array();
+var recent_candidates = JSON.parse(localStorage.getItem("cra_recent_candidates")) || [];
 
 // load the last data from localStorage (if exists)
 var last_cra_version = JSON.parse(localStorage.getItem("cra_version"));
@@ -1219,7 +1219,7 @@ function rate_display()
 
         $("#cra_recent_list").click(function () {
             recent_candidates.sort(comp_rate);
-            render_chart_list(recent_candidates, { 0: 'Recent枠', 10: 'Recent候補枠'});
+            render_chart_list(recent_candidates, { 0: 'Recent枠', 10: 'Recent候補枠' });
         });
 
         $("#cra_manage_play_data").click(function () {

--- a/chunithm.js
+++ b/chunithm.js
@@ -1,7 +1,7 @@
 // CHUNITHM Rate Analyzer (C) zk_phi 2015-
 
 // ※ localStorage のデータに互換性がなくなる場合は必ずバージョンを上げる
-var CRA_VERSION = 170101;
+var CRA_VERSION = 170113;
 
 if (!location.href.match(/^https:\/\/chunithm-net.com/)) {
     alert("CHUNITHM NET を開いているタブで実行してください。");
@@ -588,10 +588,10 @@ $("#cra_window_outer")
     .html("<div id='cra_window_inner' class='frame01_inside w450'></div>");
 $("#cra_window_inner")
     .html("<p class='cra_caution'>CAUTION</p>" +
-          "<p>12/3- Recent枠表示機能(β)とデータ提供機能の追加。</p>" +
-          "<p>9/13- スコアの取得を高速化。</p>" +
-          "<p>9/12- 単曲レートの切り捨て位置を修正。</p>" +
-          "<p>8/29- 譜面定数の判明したものから更新しています (譜面定数の調査方法は<a href='http://d.hatena.ne.jp/risette14/20150924/1443064402'>こちら</a>)。</p>" +
+          "<p>1/13- Recent枠表示機能(β)・データ提供機能の追加。</p>" +
+          "<p>バグなど気づいた方は @zk_phi までお願いします。</p>" +
+          "<p></p>" +
+          "<p>譜面定数の判明したものから更新しています (譜面定数の調査方法は<a href='http://d.hatena.ne.jp/risette14/20150924/1443064402'>こちら</a>)。</p>" +
           "<p>ツールの性質を理解したうえで、各自の判断でご利用ください。</p>" +
           "<p>ツールを閉じるには、右上の×ボタンをクリックしてください。</p>");
 

--- a/chunithm.js
+++ b/chunithm.js
@@ -661,8 +661,8 @@ function comp_id(p1, p2) {
 function push_playlog_to_recent_candidates (log) {
     var len = recent_candidates.length;
     var recent_list = [].concat(recent_candidates).sort(comp_rate).slice(0, 10);
-    var min_rate    = len >= 30 ? Math.min.apply(null, recent_list.map(function (p) { return p.rate; })) : 0;
-    var min_score   = len >= 30 ? Math.min.apply(null, recent_list.map(function (p) { return p.score; })) : 0;
+    var min_rate    = len >= 10 ? Math.min.apply(null, recent_list.map(function (p) { return p.rate; })) : 0;
+    var min_score   = len >= 10 ? Math.min.apply(null, recent_list.map(function (p) { return p.score; })) : 0;
 
     if (log.rate > min_rate) {
         if (len < 30) recent_candidates.push(log);

--- a/chunithm.js
+++ b/chunithm.js
@@ -708,9 +708,7 @@ function fetch_playlog(callback)
                             }
                         }
                     }
-                    else if (playlog.score >= 1007500 || playlog.score >= Math.min.apply(null, recent_list.map(function (p) { return p.score; }))) {
-                    }
-                    else {
+                    else if (playlog.score < 1007500 && playlog.score < Math.min.apply(null, recent_list.map(function (p) { return p.score; }))) {
                         recent_candidates.shift();
                         recent_candidates.push(playlog);
                     }

--- a/chunithm.js
+++ b/chunithm.js
@@ -422,7 +422,7 @@ var opt_rate    = 0;
 var disp_rate   = 0;
 var recent_rate = 0;
 var worst_chart_rate;
-var recent_candidate_list = new Array();
+var recent_candidates = new Array();
 var recent_list = new Array();
 
 // load the last data from localStorage (if exists)
@@ -432,7 +432,7 @@ var last_best_rate   = JSON.parse(localStorage.getItem("cra_best_rate"));
 var last_opt_rate    = JSON.parse(localStorage.getItem("cra_opt_rate"));
 var last_disp_rate   = JSON.parse(localStorage.getItem("cra_disp_rate"));
 var last_recent_rate = JSON.parse(localStorage.getItem("cra_recent_rate"));
-var last_recent_candidate_list = JSON.parse(localStorage.getItem("cra_recent_candidate_list"));
+var last_recent_candidates = JSON.parse(localStorage.getItem("cra_recent_candidates"));
 var last_recent_list = JSON.parse(localStorage.getItem("cra_recent_list"));
 
 // diff between the latest rate and the last rate
@@ -618,7 +618,7 @@ $("#cra_window_inner")
                             fecth_playlog(function () {
                                 localStorage.setItem("cra_chart_list", JSON.stringify(chart_list));
                                 localStorage.setItem("cra_version", JSON.stringify(cra_version));
-                                localStorage.setItem("cra_recent_candidate_list", JSON.stringify(recent_candidate_list));
+                                localStorage.setItem("cra_recent_candidates", JSON.stringify(recent_candidates));
                                 localStorage.setItem("cra_recent_list", JSON.stringify(recent_list));
                                 $("#cra_close_button").show(400);
                                 rate_display();
@@ -635,7 +635,7 @@ if(cra_version == last_cra_version) {
                .click(function() {
                    chart_list = last_chart_list;
                    disp_rate = last_disp_rate;
-                   recent_candidate_list = last_recent_candidate_list;
+                   recent_candidates = last_recent_candidates;
                    recent_list = last_recent_list;
                    rate_display();
                }));
@@ -648,19 +648,19 @@ $("#cra_wrapper").delay(400).fadeIn(400);
 // fetch music / user data
 // -----------------------------------------------------------------------------
 
-// use GetUserPlaylogApi to fetch playlog, and update recent_candidate_list and recent_list
+// use GetUserPlaylogApi to fetch playlog, and update recent_candidates and recent_list
 function fecth_playlog(callback)
 {
     $("#cra_window_inner").html("<p>loading playlog ...</p>");
     request_api("GetUserPlaylogApi", {}, function (d) {
         var level_name_map = ["basic", "advance", "expert", "master", "worldsend"];
-        var last_play_date = last_recent_candidate_list ? last_recent_candidate_list[last_recent_candidate_list.length - 1].play_date : 0;
+        var last_play_date = last_recent_candidates ? last_recent_candidates[last_recent_candidates.length - 1].play_date : 0;
 
-        recent_candidate_list = last_recent_candidate_list;
-        if (!recent_candidate_list) {
-            recent_candidate_list = new Array();
+        recent_candidates = last_recent_candidates;
+        if (!recent_candidates) {
+            recent_candidates = new Array();
             for (var i = 0; i < 30; i++) {
-                recent_candidate_list.push({
+                recent_candidates.push({
                     rate_base: 0,
                     score: 0,
                     rate: 0,
@@ -691,15 +691,15 @@ function fecth_playlog(callback)
                         play_date: play_date
                     };
 
-                    recent_list = [].concat(recent_candidate_list).sort(function (p1, p2) {
+                    recent_list = [].concat(recent_candidates).sort(function (p1, p2) {
                         return (p1.rate !== p2.rate) ? (p2.rate - p1.rate) : (p1.play_date - p2.play_date);
                     }).slice(0, 10);
 
                     if (playlog.rate > Math.min.apply(null, recent_list.map(function (p) { return p.rate; }))) {
-                        for (var k = 0; k < recent_candidate_list.length; k++) {
-                            if (recent_candidate_list[k].rate < playlog.rate) {
-                                recent_candidate_list.splice(k, 1);
-                                recent_candidate_list.push(playlog);
+                        for (var k = 0; k < recent_candidates.length; k++) {
+                            if (recent_candidates[k].rate < playlog.rate) {
+                                recent_candidates.splice(k, 1);
+                                recent_candidates.push(playlog);
                                 break;
                             }
                         }
@@ -707,14 +707,14 @@ function fecth_playlog(callback)
                     else if (playlog.score >= 1007500 || playlog.score >= Math.min.apply(null, recent_list.map(function (p) { return p.score; }))) {
                     }
                     else {
-                        recent_candidate_list.shift();
-                        recent_candidate_list.push(playlog);
+                        recent_candidates.shift();
+                        recent_candidates.push(playlog);
                     }
                 }
             }
         }
 
-        recent_list = [].concat(recent_candidate_list).sort(function (p1, p2) {
+        recent_list = [].concat(recent_candidates).sort(function (p1, p2) {
             return (p1.rate !== p2.rate) ? (p2.rate - p1.rate) : (p1.play_date - p2.play_date);
         }).slice(0, 10);
 
@@ -1414,17 +1414,17 @@ function render_recent_list(msgs1, msgs2)
 </div>`);
     }
 
-    for (var i = 0; i < recent_candidate_list.length; i++) {
-        var index = recent_candidate_list.length - (i + 1);
+    for (var i = 0; i < recent_candidates.length; i++) {
+        var index = recent_candidates.length - (i + 1);
         if (msgs2[i])
             $("#cra_chart_list")
                 .append("<hr>")
                 .append(dom(["div", { class: "mt_15" }, ["h2#page_title", msgs2[i]]]));
 
-        if (!recent_candidate_list[index].id || isNaN(recent_candidate_list[index].id))
+        if (!recent_candidates[index].id || isNaN(recent_candidates[index].id))
             continue;
 
-        var difficulty_icon = recent_candidate_list[index].level == 2 ? "common/images/icon_expert.png"
+        var difficulty_icon = recent_candidates[index].level == 2 ? "common/images/icon_expert.png"
             : "common/images/icon_master.png";
 
         var $list_item = $("<div class='frame02 w400 cra_chart_list_item'>")
@@ -1435,7 +1435,7 @@ function render_recent_list(msgs1, msgs2)
 <div class="play_jacket_side">
   <div class="play_jacket_area">
     <div id="Jacket" class="play_jacket_img">
-      <img src=${recent_candidate_list[index].image}>
+      <img src=${recent_candidates[index].image}>
     </div>
   </div>
 </div>
@@ -1445,22 +1445,22 @@ function render_recent_list(msgs1, msgs2)
       <img src="${difficulty_icon}">
     </div>
     <div id="Track" class="play_track_text">
-      ${rate_str(recent_candidate_list[index].rate_base)}
+      ${rate_str(recent_candidates[index].rate_base)}
     </div>
   </div>
   <div class="box02 play_musicdata_block">
     <div id="MusicTitle" class="play_musicdata_title">
-      ${recent_candidate_list[index].name}
+      ${recent_candidates[index].name}
     </div>
     <div class="play_musicdata_score clearfix">
       <div class="play_musicdata_score_text">
-        Score：<span id="Score">${recent_candidate_list[index].score}</span>
+        Score：<span id="Score">${recent_candidates[index].score}</span>
       </div>
       <br>
       <div class="play_musicdata_score_text">
         Rate：
         <span id="Rate">
-          ${rate_str(recent_candidate_list[index].rate)}
+          ${rate_str(recent_candidates[index].rate)}
         </span>
       </div>
     </div>

--- a/chunithm.js
+++ b/chunithm.js
@@ -660,14 +660,10 @@ function push_playlog_to_recent_candidates (playlog) {
     var min_rate    = Math.min.apply(null, recent_list.map(function (p) { return p.rate; }));
     var min_score   = Math.min.apply(null, recent_list.map(function (p) { return p.score; }));
 
-    if (playlog.length < 30) {
-        recent_candidates.push(playlog);
-    }
-
     else if (playlog.rate > min_rate) {
         for (var k = 0; k < recent_candidates.length; k++) {
             if (recent_candidates[k].rate < playlog.rate) {
-                recent_candidates.splice(k, 1);
+                if (playlog.length >= 30) recent_candidates.splice(k, 1);
                 recent_candidates.push(playlog);
                 break;
             }
@@ -675,7 +671,7 @@ function push_playlog_to_recent_candidates (playlog) {
     }
 
     else if (playlog.score < 1007500 && playlog.score < min_score) {
-        recent_candidates.shift();
+        if (playlog.length >= 30) recent_candidates.shift();
         recent_candidates.push(playlog);
     }
 }

--- a/chunithm.js
+++ b/chunithm.js
@@ -1284,7 +1284,7 @@ function render_chart_list(list, msgs)
 
         // 満点出しても BEST 枠を改善できない譜面を出さない（Recent 枠
         // の場合は req_diff = undefined なので影響しない）
-        if (isNaN(list[i].req_diff)) continue;
+        if (list[i].req_diff && isNaN(list[i].req_diff)) continue;
 
         var difficulty_icon = list[i].level == 2 ? "common/images/icon_expert.png"
             : "common/images/icon_master.png";

--- a/chunithm.js
+++ b/chunithm.js
@@ -629,8 +629,8 @@ $("#cra_wrapper").delay(400).fadeIn(400);
 
 // Create playlog entity if music_info exists. Otherwise return null.
 function playlog(id, level, score, play_date /* optional */) {
-    var music_info = music_info[id];
-    var rate_base  = music_info && music_info.rate_base[id];
+    var info = music_info[id];
+    var rate_base  = info && info.rate_base[id];
     if (!rate_base) return null;
     return {
         id:        id,
@@ -655,24 +655,24 @@ function comp_id(p1, p2) {
 }
 
 // push new playlog to recent_candidates if appropriate.
-function push_playlog_to_recent_candidates (playlog) {
+function push_playlog_to_recent_candidates (log) {
     var recent_list = [].concat(recent_candidates).sort(comp_rate).slice(0, 10);
     var min_rate    = Math.min.apply(null, recent_list.map(function (p) { return p.rate; }));
     var min_score   = Math.min.apply(null, recent_list.map(function (p) { return p.score; }));
 
-    if (playlog.rate > min_rate) {
+    if (log.rate > min_rate) {
         for (var k = 0; k < recent_candidates.length; k++) {
-            if (recent_candidates[k].rate < playlog.rate) {
+            if (recent_candidates[k].rate < log.rate) {
                 if (playlog.length >= 30) recent_candidates.splice(k, 1);
-                recent_candidates.push(playlog);
+                recent_candidates.push(log);
                 break;
             }
         }
     }
 
-    else if (playlog.score < 1007500 && playlog.score < min_score) {
-        if (playlog.length >= 30) recent_candidates.shift();
-        recent_candidates.push(playlog);
+    else if (log.score < 1007500 && log.score < min_score) {
+        if (log.length >= 30) recent_candidates.shift();
+        recent_candidates.push(log);
     }
 }
 
@@ -684,14 +684,14 @@ function fetch_playlog(callback)
     request_api("GetUserPlaylogApi", {}, function (d) {
         var last_play_date = recent_candidates[recent_candidates.length - 1].play_date;
         for (var i = d.userPlaylogList.length - 1; i >= 0; i--) {
-            var playlog = playlog(
+            var log = playlog(
                 d.userPlaylogList[i].musicId,
                 level_name_map[d.userPlaylogList[i].levelName],
                 d.userPlaylogList[i].score,
                 d.userPlaylogList[i].userPlayDate
             );
-            if (playlog && playlog.play_date > last_play_date)
-                push_playlog_to_recent_candidates(playlog);
+            if (log && log.play_date > last_play_date)
+                push_playlog_to_recent_candidates(log);
         }
         callback();
     }, function () {
@@ -707,12 +707,12 @@ function fetch_score_data(level, callback)
         level: "1990" + level
     }, function(d) {
         for (var i = 0; i < d.userMusicList.length; i++) {
-            var playlog = playlog(
+            var log = playlog(
                 d.userMusicList[i].musicId,
                 level,
                 d.userMusicList[i].scoreMax
             );
-            if (playlog) best_list.push(playlog);
+            if (log) best_list.push(log);
         }
         callback();
     }, function() {
@@ -1283,14 +1283,14 @@ function render_chart_list(list, msgs)
         var $list_item = $("<div class='frame02 w400 cra_chart_list_item'>")
             .appendTo("#cra_chart_list");
 
-        var music_info = music_info[list[i].id];
+        var info = music_info[list[i].id];
 
         $list_item
             .html(`
 <div class="play_jacket_side">
   <div class="play_jacket_area">
     <div id="Jacket" class="play_jacket_img">
-      <img src=${music_info.image}>
+      <img src=${info.image}>
     </div>
   </div>
 </div>
@@ -1305,7 +1305,7 @@ function render_chart_list(list, msgs)
   </div>
   <div class="box02 play_musicdata_block">
     <div id="MusicTitle" class="play_musicdata_title">
-      ${music_info.name}
+      ${info.name}
     </div>
     <div class="play_musicdata_score clearfix">
       <div class="play_musicdata_score_text">

--- a/chunithm.js
+++ b/chunithm.js
@@ -28,230 +28,230 @@ var DEPENDENCIES = [
 
 var LEVEL_ID = { basic: 0, advance: 1, expert: 2, master: 3, worldsend: 4 };
 
-var MUSIC_INFO = {
-     003: { rate_base: {          3: 11.8 }, image: "img/d739ba44da6798a0.jpg", name: "B.B.K.K.B.K.K." }
-    ,005: { rate_base: {          3: 11.3 }, image: "img/38faf81803b730f3.jpg", name: "Scatman (Ski Ba Bop Ba Dop Bop)" }
-    ,006: { rate_base: {          3: 12.3 }, image: "img/90589be457544570.jpg", name: "Reach for the Stars" }
-    ,007: { rate_base: { 2: 12.0, 3: 13.6 }, image: "img/b602913a68fca621.jpg", name: "初音ミクの消失" }
-    ,009: { rate_base: {          3: 11.3 }, image: "img/fce0bad9123dcd76.jpg", name: "情熱大陸" }
-    ,010: { rate_base: {          3: 11.7 }, image: "img/0d7bd146ebed6fba.jpg", name: "All I Want" }
-    ,014: { rate_base: {          3: 11.0 }, image: "img/af78dd039a36a4c7.jpg", name: "コネクト" }
-    ,017: { rate_base: {          3: 11.1 }, image: "img/696d4f956ebb4209.jpg", name: "空色デイズ" }
-    ,018: { rate_base: {          3: 11.2 }, image: "img/3c2606abe4dded71.jpg", name: "千本桜" }
-    ,019: { rate_base: {          3: 13.2 }, image: "img/0b98b8b4e7cfd997.jpg", name: "DRAGONLADY" }
-    ,021: { rate_base: {          3: 11.9 }, image: "img/4f69fb126f579c2f.jpg", name: "ナイト・オブ・ナイツ" }
-    ,023: { rate_base: {          3: 12.1 }, image: "img/b8ab9573859ebe4f.jpg", name: "一触即発☆禅ガール" }
-    ,027: { rate_base: {          3: 12.5 }, image: "img/fdc3bb451f6403d2.jpg", name: "タイガーランペイジ" }
-    ,033: { rate_base: {          3: 13.0 }, image: "img/fddc37caee47286d.jpg", name: "Blue Noise" }
-    ,035: { rate_base: {          3: 12.4 }, image: "img/aabf49add818546d.jpg", name: "Lapis" }
-    ,036: { rate_base: {          3: 11.0 }, image: "img/e273c9d64170b575.jpg", name: "届かない恋 '13" }
-    ,037: { rate_base: {          3: 11.3 }, image: "img/335dbb14cedb70bf.jpg", name: "鳥の詩" }
-    ,038: { rate_base: {          3: 11.0 }, image: "img/529d98ad07709ae5.jpg", name: "天ノ弱" }
-    ,041: { rate_base: {          3: 11.6 }, image: "img/7f17441bc2582ec8.jpg", name: "sweet little sister" }
-    ,042: { rate_base: {          3: 11.6 }, image: "img/4bbc4ec5ee9aa0b6.jpg", name: "oath sign" }
-    ,045: { rate_base: {          3: 12.2 }, image: "img/90dca26c66c5d5b7.jpg", name: "L9" }
-    ,047: { rate_base: {          3: 12.0 }, image: "img/5cb17a59f4b8c133.jpg", name: "六兆年と一夜物語" }
-    ,048: { rate_base: {          3: 11.8 }, image: "img/b38eba298df2c6db.jpg", name: "Unlimited Spark!" }
-    ,051: { rate_base: {          3: 12.7 }, image: "img/161f13a787a00032.jpg", name: "My First Phone" }
-    ,052: { rate_base: { 2: 11.1, 3: 13.2 }, image: "img/a62f975edc860e34.jpg", name: "Cyberozar" }
-    ,053: { rate_base: {          3: 12.3 }, image: "img/73ad66e81061bba3.jpg", name: "Teriqma" }
-    ,055: { rate_base: {          3: 11.2 }, image: "img/506f053a80e1b28e.jpg", name: "夏祭り" }
-    ,056: { rate_base: {          3: 11.0 }, image: "img/2535487ae13b2fd8.jpg", name: "そばかす" }
-    ,060: { rate_base: {          3: 11.3 }, image: "img/3bee1cce7d794f31.jpg", name: "only my railgun" }
-    ,061: { rate_base: { 2: 11.0, 3: 13.5 }, image: "img/2ccf97477eaf45ad.jpg", name: "GOLDEN RULE" }
-    ,062: { rate_base: {          3: 12.4 }, image: "img/9386971505bb20b0.jpg", name: "名も無い鳥" }
-    ,063: { rate_base: { 2: 11.7, 3: 13.1 }, image: "img/2df15f390356067f.jpg", name: "Gate of Fate" }
-    ,064: { rate_base: {          3: 12.7 }, image: "img/6bf934fede23724d.jpg", name: "今ぞ♡崇め奉れ☆オマエらよ！！～姫の秘メタル渇望～" }
-    ,065: { rate_base: {          3: 11.1 }, image: "img/713d52aa40ed7fc4.jpg", name: "Anemone" }
-    ,066: { rate_base: {          3: 12.3 }, image: "img/c22702914849a11a.jpg", name: "明るい未来" }
-    ,067: { rate_base: {          3: 11.2 }, image: "img/11437ebc94947550.jpg", name: "昵懇レファレンス" }
-    ,068: { rate_base: {          3: 11.7 }, image: "img/145b9b6f4c27d78e.jpg", name: "乗り切れ受験ウォーズ" }
-    ,069: { rate_base: { 2: 11.9, 3: 13.3 }, image: "img/c2c4ece2034eb620.jpg", name: "The wheel to the right" }
-    ,070: { rate_base: {          3: 12.4 }, image: "img/3ccebd87235f591c.jpg", name: "STAR" }
-    ,071: { rate_base: {          3: 12.3 }, image: "img/2bf02bef3051ecaf.jpg", name: "Infantoon Fantasy" }
-    ,072: { rate_base: {          3: 13.5 }, image: "img/ec3a366b4724f8f6.jpg", name: "Genesis" }
-    ,073: { rate_base: {          3: 12.6 }, image: "img/0c2791f737ce1ff2.jpg", name: "MUSIC PЯAYER" }
-    ,074: { rate_base: {          3: 11.0 }, image: "img/feef37ed3d91cfbd.jpg", name: "リリーシア" }
-    ,075: { rate_base: {          3: 11.7 }, image: "img/e1454dc2eeae2030.jpg", name: "Counselor" }
-    ,076: { rate_base: { 2: 11.8, 3: 13.4 }, image: "img/93abb77776c70b47.jpg", name: "luna blu" }
-    ,077: { rate_base: {          3: 12.8 }, image: "img/01fc7f761272bfb4.jpg", name: "ケモノガル" }
-    ,079: { rate_base: {          3: 11.0 }, image: "img/281f821a06a7da18.jpg", name: "ＧＯ！ＧＯ！ラブリズム♥" }
-    ,082: { rate_base: {          3: 12.5 }, image: "img/27ef71f8a76f1e8a.jpg", name: "Memories of Sun and Moon" }
-    ,083: { rate_base: {          3: 12.2 }, image: "img/181682bf5b277726.jpg", name: "ロストワンの号哭" }
-    ,088: { rate_base: {          3: 12.1 }, image: "img/c4223e68340efa41.jpg", name: "The Concept of Love" }
-    ,090: { rate_base: { 2: 11.6, 3: 13.2 }, image: "img/19d57f9a7652308a.jpg", name: "L'épisode" }
-    ,091: { rate_base: {          3: 11.2 }, image: "img/cb77a66b62023890.jpg", name: "Yet Another ”drizzly rain”" }
-    ,092: { rate_base: {          3: 12.8 }, image: "img/17315fb464f265bd.jpg", name: "最終鬼畜妹・一部声" }
-    ,093: { rate_base: {          3: 12.3 }, image: "img/6b40809324937ec9.jpg", name: "蒼空に舞え、墨染の桜" }
-    ,094: { rate_base: {          3: 12.3 }, image: "img/164258c65c714d50.jpg", name: "セツナトリップ" }
-    ,095: { rate_base: {          3: 12.1 }, image: "img/db38c119e4d8933e.jpg", name: "砂漠のハンティングガール♡" }
-    ,096: { rate_base: {          3: 11.8 }, image: "img/9d2ebc847487e01b.jpg", name: "チルノのパーフェクトさんすう教室" }
-    ,098: { rate_base: {          3: 11.4 }, image: "img/f7e67efaf6ced6ea.jpg", name: "魔理沙は大変なものを盗んでいきました" }
-    ,099: { rate_base: {          3: 11.7 }, image: "img/ee332e6fa86661fd.jpg", name: "言ノ葉カルマ" }
-    ,101: { rate_base: {          3: 12.9 }, image: "img/81e347d3b96b2ae1.jpg", name: "Tango Rouge" }
-    ,102: { rate_base: {          3: 12.5 }, image: "img/7fc6ae1b488b88de.jpg", name: "Tuning Rangers" }
-    ,103: { rate_base: { 2: 11.7, 3: 13.7 }, image: "img/3210d321c2700a57.jpg", name: "エンドマークに希望と涙を添えて" }
-    ,104: { rate_base: {          3: 12.5 }, image: "img/ff945c9cb9e43e83.jpg", name: "とーきょー全域★アキハバラ？" }
-    ,106: { rate_base: { 2: 12.2, 3: 13.8 }, image: "img/8219519cc94d5524.jpg", name: "宛城、炎上！！" }
-    ,107: { rate_base: {          3: 13.0 }, image: "img/b43fef626f5b88cd.jpg", name: "We Gonna Journey" }
-    ,108: { rate_base: {          3: 12.0 }, image: "img/1ec3213366f4ad57.jpg", name: "The ether" }
-    ,110: { rate_base: {          3: 11.2 }, image: "img/d42200159ef91521.jpg", name: "Magia" }
-    ,111: { rate_base: {          3: 11.3 }, image: "img/7ad659a57ef26888.jpg", name: "staple stable" }
-    ,112: { rate_base: {          3: 11.0 }, image: "img/3dc05a281c0724f7.jpg", name: "マジLOVE1000%" }
-    ,113: { rate_base: {          3: 11.4 }, image: "img/3f8eb68a4f6089dc.jpg", name: "ストリーミングハート" }
-    ,114: { rate_base: {          3: 11.4 }, image: "img/b02c3912d1524d5c.jpg", name: "Sweet Devil" }
-    ,115: { rate_base: {          3: 11.5 }, image: "img/9165ee58223accc0.jpg", name: "Dreaming" }
-    ,117: { rate_base: {          3: 11.5 }, image: "img/88124d980ac7eca4.jpg", name: "M.S.S.Planet" }
-    ,118: { rate_base: {          3: 12.0 }, image: "img/17e485acfe11a67f.jpg", name: "腐れ外道とチョコレゐト" }
-    ,119: { rate_base: {          3: 12.3 }, image: "img/a7dd6716fcae0cb8.jpg", name: "アウターサイエンス" }
-    ,120: { rate_base: {          3: 12.7 }, image: "img/a84a31e562efd7a0.jpg", name: "四次元跳躍機関" }
-    ,121: { rate_base: {          3: 12.5 }, image: "img/4196f71ce51620a0.jpg", name: "東方妖々夢 ～the maximum moving about～" }
-    ,122: { rate_base: {          3: 12.5 }, image: "img/67418ba28151c3ff.jpg", name: "少女幻葬戦慄曲　～　Necro Fantasia" }
-    ,124: { rate_base: {          3: 12.5 }, image: "img/74ce2f0a4b4f6fe2.jpg", name: "夏影" }
-    ,126: { rate_base: {          3: 11.3 }, image: "img/547ba5407b6e7fa0.jpg", name: "Heart To Heart" }
-    ,128: { rate_base: {          3: 12.7 }, image: "img/7edc6879319accfd.jpg", name: "The Formula" }
-    ,129: { rate_base: {          3: 11.2 }, image: "img/f56cd36303a3239a.jpg", name: "Hacking to the Gate" }
-    ,130: { rate_base: {          3: 11.7 }, image: "img/e4df0d48302ccd26.jpg", name: "スカイクラッドの観測者" }
-    ,131: { rate_base: {          3: 12.6 }, image: "img/38d3c5a5a45c6d07.jpg", name: "チルドレンレコード" }
-    ,132: { rate_base: {          3: 12.2 }, image: "img/1c508bbd42d335fe.jpg", name: "イカサマライフゲイム" }
-    ,134: { rate_base: { 2: 11.8, 3: 13.7 }, image: "img/08a24ed249ed2eec.jpg", name: "HAELEQUIN (Original Remaster)" }
-    ,135: { rate_base: {          3: 13.5 }, image: "img/e7ee14d9fe63d072.jpg", name: "Vallista" }
-    ,136: { rate_base: {          3: 12.5 }, image: "img/c4f977d264deafb1.jpg", name: "Äventyr" }
-    ,137: { rate_base: {          3: 13.6 }, image: "img/13a5a9ca35a9b71b.jpg", name: "Angel dust" }
-    ,138: { rate_base: {          3: 13.0 }, image: "img/478e8835e382f740.jpg", name: "conflict" }
-    ,140: { rate_base: {          3: 11.9 }, image: "img/0aad2e0ff661e7d1.jpg", name: "Guilty" }
-    ,141: { rate_base: { 2: 11.5, 3: 13.3 }, image: "img/2e6c11edba79d997.jpg", name: "閃鋼のブリューナク" }
-    ,142: { rate_base: {          3: 12.6 }, image: "img/a8d181c5442df7d2.jpg", name: "Altale" }
-    ,144: { rate_base: {          3: 13.3 }, image: "img/8b04b9ad2d49850c.jpg", name: "Aragami" }
-    ,145: { rate_base: {          3: 11.8 }, image: "img/0bb58f15b16703ab.jpg", name: "Change Our MIRAI！" }
-    ,146: { rate_base: {          3: 11.7 }, image: "img/d3b40f7b8e0758ff.jpg", name: "夕暮れワンルーム" }
-    ,148: { rate_base: {          3: 11.0 }, image: "img/cd458a75aa049889.jpg", name: "Theme of SeelischTact" }
-    ,149: { rate_base: {          3: 11.7 }, image: "img/c9c2fa20dcd9a46e.jpg", name: "緋色のDance" }
-    ,150: { rate_base: {          3: 11.8 }, image: "img/2a41ad71b77d12c9.jpg", name: "brilliant better" }
-    ,151: { rate_base: {          3: 12.5 }, image: "img/7237488215dbd1d3.jpg", name: "Alma" }
-    ,152: { rate_base: { 2: 11.7, 3: 13.0 }, image: "img/f63fab30a7b6f160.jpg", name: "Gustav Battle" }
-    ,154: { rate_base: {          3: 12.7 }, image: "img/2e9fdbbc15ade5cb.jpg", name: "SAVIOR OF SONG" }
-    ,156: { rate_base: {          3: 11.5 }, image: "img/b33923bd4e6e5609.jpg", name: "FREELY TOMORROW" }
-    ,157: { rate_base: {          3: 12.8 }, image: "img/573109ca9050f55d.jpg", name: "ギガンティック O.T.N" }
-    ,158: { rate_base: {          3: 11.0 }, image: "img/e3ce6712e8cddf10.jpg", name: "フォルテシモBELL" }
-    ,159: { rate_base: {          3: 13.3 }, image: "img/d5a47266b4fe0bfe.jpg", name: "ジングルベル" }
-    ,160: { rate_base: {          3: 11.5 }, image: "img/809bf2b3f8effa6f.jpg", name: "言ノ葉遊戯" }
-    ,161: { rate_base: {          3: 12.4 }, image: "img/4ceb5aed4a4a1c47.jpg", name: "私の中の幻想的世界観及びその顕現を想起させたある現実での出来事に関する一考察" }
-    ,163: { rate_base: {          3: 11.3 }, image: "img/fd6847e3bb2e3629.jpg", name: "幾四音-Ixion-" }
-    ,165: { rate_base: {          3: 12.8 }, image: "img/1e85c4b6775c84b0.jpg", name: "ぼくらの16bit戦争" }
-    ,166: { rate_base: {          3: 11.8 }, image: "img/5a0ac8501e3b95ce.jpg", name: "裏表ラバーズ" }
-    ,167: { rate_base: {          3: 12.7 }, image: "img/24611f2e2374e6a8.jpg", name: "脳漿炸裂ガール" }
-    ,168: { rate_base: {          3: 11.9 }, image: "img/1982767436fc52d8.jpg", name: "ネトゲ廃人シュプレヒコール" }
-    ,169: { rate_base: {          3: 11.4 }, image: "img/f092ddd9e1fe088b.jpg", name: "elegante" }
-    ,171: { rate_base: {          3: 12.3 }, image: "img/25abef88cb12af3e.jpg", name: "XL TECHNO" }
-    ,173: { rate_base: {          3: 13.1 }, image: "img/2e95529be9118a11.jpg", name: "Halcyon" }
-    ,176: { rate_base: {          3: 11.3 }, image: "img/aa0cefb5a0f00457.jpg", name: "Dance!" }
-    ,177: { rate_base: {          3: 12.6 }, image: "img/6e7843f9d831b0ac.jpg", name: "Jimang Shot" }
-    ,178: { rate_base: {          3: 12.7 }, image: "img/9f281db3bcc9353b.jpg", name: "stella=steLLa" }
-    ,179: { rate_base: {          3: 11.1 }, image: "img/0e73189a7083e4f4.jpg", name: "すろぉもぉしょん" }
-    ,180: { rate_base: { 2: 12.4, 3: 13.9 }, image: "img/a732d43fd2a11e8f.jpg", name: "怒槌" }
-    ,185: { rate_base: {          3: 11.2 }, image: "img/520c1fef62954ca6.jpg", name: "楽園の翼" }
-    ,187: { rate_base: {          3: 13.2 }, image: "img/e6642a96885723c1.jpg", name: "患部で止まってすぐ溶ける～狂気の優曇華院" }
-    ,189: { rate_base: {          3: 12.7 }, image: "img/9310d07b7e02e73a.jpg", name: "ひれ伏せ愚民どもっ！" }
-    ,190: { rate_base: {          3: 12.6 }, image: "img/bbaa464731ab96a4.jpg", name: "エテルニタス・ルドロジー" }
-    ,196: { rate_base: { 2: 11.9, 3: 13.7 }, image: "img/ed40032f25177518.jpg", name: "FREEDOM DiVE" }
-    ,197: { rate_base: { 2: 11.2, 3: 13.1 }, image: "img/ae6d3a8806e09613.jpg", name: "Jack-the-Ripper◆" }
-    ,199: { rate_base: {          3: 12.1 }, image: "img/d76afb63de1417f8.jpg", name: "ハート・ビート" }
-    ,200: { rate_base: {          3: 12.1 }, image: "img/569e7b07c0696bc7.jpg", name: "無敵We are one!!" }
-    ,201: { rate_base: { 2: 12.4, 3: 13.9 }, image: "img/a251c24a3cc4dbf7.jpg", name: "Contrapasso -inferno-" }
-    ,202: { rate_base: { 2: 11.2, 3: 13.1 }, image: "img/45112e2818cf80a2.jpg", name: "GEMINI -C-" }
-    ,203: { rate_base: {          3: 12.0 }, image: "img/101d4e7b03a5a89e.jpg", name: "FLOWER" }
-    ,204: { rate_base: {          3: 11.0 }, image: "img/1ea73ffbba6d7ead.jpg", name: "ちくわパフェだよ☆CKP" }
-    ,205: { rate_base: {          3: 12.7 }, image: "img/3d7803669dd3fcb9.jpg", name: "SNIPE WHOLE" }
-    ,206: { rate_base: {          3: 11.4 }, image: "img/e10bbd173df15772.jpg", name: "Signs Of Love (“Never More” ver.)" }
-    ,207: { rate_base: {          3: 11.7 }, image: "img/5151993f923b06a5.jpg", name: "Your Affection (Daisuke Asakura Remix)" }
-    ,208: { rate_base: {          3: 12.7 }, image: "img/5bab1a38b98d59b5.jpg", name: "SAMBISTA" }
-    ,209: { rate_base: {          3: 11.7 }, image: "img/5744f4cf66710a56.jpg", name: "君色シグナル" }
-    ,210: { rate_base: {          3: 12.4 }, image: "img/040cd43234aed57a.jpg", name: "アスノヨゾラ哨戒班" }
-    ,211: { rate_base: {          3: 12.2 }, image: "img/d99079fecaa936ab.jpg", name: "天樂" }
-    ,212: { rate_base: {          3: 12.1 }, image: "img/1ee29f73ee8f53d0.jpg", name: "いろは唄" }
-    ,213: { rate_base: {          3: 11.9 }, image: "img/c6d494f528391d1c.jpg", name: "星屑ユートピア" }
-    ,214: { rate_base: {          3: 11.9 }, image: "img/f4a2d88c38669f72.jpg", name: "青春はNon-Stop!" }
-    ,215: { rate_base: {          3: 12.4 }, image: "img/81cc90c04676f18b.jpg", name: "Falling Roses" }
-    ,216: { rate_base: {          3: 12.3 }, image: "img/3227722a8345a950.jpg", name: "放課後革命" }
-    ,217: { rate_base: {          3: 11.8 }, image: "img/2b3c90b1dab1ecff.jpg", name: "楽園ファンファーレ" }
-    ,219: { rate_base: { 2: 12.7, 3: 13.9 }, image: "img/246f63902c4b0f89.jpg", name: "玩具狂奏曲 -終焉-" }
-    ,220: { rate_base: {          3: 12.3 }, image: "img/c3041fd82b0a0710.jpg", name: "如月アテンション" }
-    ,222: { rate_base: {          3: 12.9 }, image: "img/ad33a423c865bed1.jpg", name: "Mr. Wonderland" }
-    ,223: { rate_base: { 2: 11.0, 3: 13.0 }, image: "img/8ec9a26e11ec1a40.jpg", name: "カミサマネジマキ" }
-    ,224: { rate_base: {          3: 11.1 }, image: "img/b9d170f84c1bb5d3.jpg", name: "恋愛裁判" }
-    ,225: { rate_base: {          3: 12.1 }, image: "img/6f86e2a47e9a283c.jpg", name: "ウミユリ海底譚" }
-    ,226: { rate_base: { 2: 12.3, 3: 13.8 }, image: "img/993b5cddb9d9badf.jpg", name: "Garakuta Doll Play" }
-    ,227: { rate_base: {          3: 11.5 }, image: "img/74c77deb2f2e5e07.jpg", name: "洗脳" }
-    ,228: { rate_base: {          3: 12.0 }, image: "img/882be51fe439614d.jpg", name: "このふざけた素晴らしき世界は、僕の為にある" }
-    ,229: { rate_base: { 2: 11.9, 3: 13.4 }, image: "img/73f86aec8d6c7c9b.jpg", name: "紅華刑" }
-    ,230: { rate_base: {          3: 12.4 }, image: "img/b59d2b2ab877a77d.jpg", name: "Hyperion" }
-    ,232: { rate_base: { 2: 11.3, 3: 13.4 }, image: "img/a2069fdb9d860d36.jpg", name: "Elemental Creation" }
-    ,233: { rate_base: {          3: 12.2 }, image: "img/5fe5db1d2e40ee7a.jpg", name: "アルストロメリア" }
-    ,235: { rate_base: {          3: 12.5 }, image: "img/8b84b06033585428.jpg", name: "ファッとして桃源郷" }
-    ,238: { rate_base: {          3: 11.9 }, image: "img/4c769ae611f83d21.jpg", name: "フレンズ" }
-    ,240: { rate_base: {          3: 12.6 }, image: "img/47397105bad447fb.jpg", name: "夜咄ディセイブ" }
-    ,243: { rate_base: {          3: 12.2 }, image: "img/8872c759bea3bd9f.jpg", name: "シュガーソングとビターステップ" }
-    ,244: { rate_base: {          3: 12.3 }, image: "img/e0a700914896ea4a.jpg", name: "回レ！雪月花" }
-    ,245: { rate_base: {          3: 11.4 }, image: "img/630ac5b31e8ab816.jpg", name: "Help me, あーりん！" }
-    ,246: { rate_base: {          3: 12.7 }, image: "img/d445e4878a818d8b.jpg", name: "なるとなぎのパーフェクトロックンロール教室" }
-    ,247: { rate_base: {          3: 11.9 }, image: "img/58847f9694837c0b.jpg", name: "絶世スターゲイト" }
-    ,248: { rate_base: { 2: 12.3, 3: 13.9 }, image: "img/a2fdef9e4b278a51.jpg", name: "Schrecklicher Aufstand" }
-    ,250: { rate_base: { 2: 11.8, 3: 13.5 }, image: "img/989f4458fb34aa9d.jpg", name: "Philosopher" }
-    ,251: { rate_base: {          3: 12.5 }, image: "img/457722c9f3ff5473.jpg", name: "Crazy ∞ nighT" }
-    ,252: { rate_base: {          3: 12.3 }, image: "img/bb221e3de960de7d.jpg", name: "愛迷エレジー" }
-    ,254: { rate_base: {          3: 11.7 }, image: "img/2e617d713547fe84.jpg", name: "その群青が愛しかったようだった" }
-    ,255: { rate_base: {          3: 11.1 }, image: "img/429d34fef5fddb02.jpg", name: "激情！ミルキィ大作戦" }
-    ,257: { rate_base: {          3: 13.0 }, image: "img/bef9b79c637bf4c9.jpg", name: "BOKUTO" }
-    ,259: { rate_base: { 2: 11.3, 3: 13.1 }, image: "img/4d66e5d1669d79a2.jpg", name: "Oshama Scramble! (Cranky Remix)" }
-    ,260: { rate_base: {          3: 12.4 }, image: "img/03f1dafe3b08607e.jpg", name: "D.E.A.D.L.Y." }
-    ,261: { rate_base: {          3: 12.3 }, image: "img/6e917606db3c5a0e.jpg", name: "ロボットプラネットユートピア" }
-    ,262: { rate_base: {          3: 13.6 }, image: "img/676e59847912f5ca.jpg", name: "Tidal Wave" }
-    ,263: { rate_base: {          3: 11.7 }, image: "img/015358a0c0580022.jpg", name: "Hand in Hand" }
-    ,264: { rate_base: {          3: 12.2 }, image: "img/f44c6b628889f8ec.jpg", name: "My Dearest Song" }
-    ,267: { rate_base: {          3: 11.5 }, image: "img/a0d03551eb3930e9.jpg", name: "心象蜃気楼" }
-    ,270: { rate_base: {          3: 12.3 }, image: "img/21dfcd3ae2c5c370.jpg", name: "エンヴィキャットウォーク" }
-    ,273: { rate_base: {          3: 11.8 }, image: "img/604157e2c49d91d7.jpg", name: "ビバハピ" }
-    ,276: { rate_base: {          3: 12.4 }, image: "img/82105b37d18450b6.jpg", name: "後夜祭" }
-    ,278: { rate_base: {          3: 11.4 }, image: "img/5f1d7a520a2735d4.jpg", name: "からくりピエロ" }
-    ,279: { rate_base: {          3: 11.7 }, image: "img/84ecaebe6bce2a58.jpg", name: "深海少女" }
-    ,281: { rate_base: {          3: 13.4 }, image: "img/330e57eeeb0fb2cd.jpg", name: "ラクガキスト" }
-    ,286: { rate_base: {          3: 11.5 }, image: "img/afcce0c85c1f8610.jpg", name: "Tell Your World" }
-    ,287: { rate_base: {          3: 11.9 }, image: "img/5febf5df2b5094f3.jpg", name: "ロミオとシンデレラ" }
-    ,288: { rate_base: {          3: 11.6 }, image: "img/f29f10a963df60cf.jpg", name: "First Twinkle" }
-    ,289: { rate_base: {          3: 12.7 }, image: "img/0cece587cced4d3f.jpg", name: "ウソラセラ" }
-    ,290: { rate_base: {          3: 11.3 }, image: "img/b1d08379f05c706e.jpg", name: "檄!帝国華撃団" }
-    ,291: { rate_base: {          3: 12.4 }, image: "img/9c5e71b3588dbc70.jpg", name: "Kronos" }
-    ,292: { rate_base: {          3: 12.0 }, image: "img/b12c25f87b1d036e.jpg", name: "月に叢雲華に風" }
-    ,293: { rate_base: {          3: 13.2 }, image: "img/c58227eb0d14938c.jpg", name: "インビジブル" }
-    ,296: { rate_base: {          3: 12.1 }, image: "img/76535cf4c728f2af.jpg", name: "かくしん的☆めたまるふぉ～ぜっ!" }
-    ,298: { rate_base: {          3: 12.6 }, image: "img/7c649691aa0c4b3d.jpg", name: "PRIVATE SERVICE" }
-    ,299: { rate_base: {          3: 11.4 }, image: "img/9bd44690db5375ac.jpg", name: "secret base ～君がくれたもの～ (10 years after Ver.)" }
-    ,300: { rate_base: {          3: 12.2 }, image: "img/012eb1ed09577836.jpg", name: "No Routine" }
-    ,304: { rate_base: {          3: 11.7 }, image: "img/16cb8567115a2f2c.jpg", name: "In The Blue Sky ’01" }
-    ,305: { rate_base: { 2: 11.0, 3: 13.3 }, image: "img/266bd38219201fa1.jpg", name: "幻想のサテライト" }
-    ,306: { rate_base: {          3: 12.2 }, image: "img/106d9eec68ed84b3.jpg", name: "凛として咲く花の如く" }
-    ,307: { rate_base: {          3: 12.7 }, image: "img/ff9f70c8c0d9f24e.jpg", name: "Paqqin" }
-    ,308: { rate_base: {          3: 11.9 }, image: "img/f8d3f2e57ae2ff24.jpg", name: "fake!fake!" }
-    ,309: { rate_base: {          3: 12.5 }, image: "img/cee51d69c428f8f5.jpg", name: "Rising Hope" }
-    ,313: { rate_base: {          3: 11.4 }, image: "img/5ac018495d6f01a5.jpg", name: "ひだまりデイズ" }
-    ,316: { rate_base: {          3: 11.5 }, image: "img/88f9536c08cb4e3f.jpg", name: "みくみくにしてあげる♪【してやんよ】" }
-    ,317: { rate_base: {          3: 13.4 }, image: "img/db15d5b7aefaa672.jpg", name: "Air" }
-    ,318: { rate_base: {          3: 13.1 }, image: "img/f803d578eb4047eb.jpg", name: "DataErr0r" }
-    ,319: { rate_base: {          3: 12.6 }, image: "img/e9eeb98572b140bc.jpg", name: "Say A Vengeance" }
-    ,320: { rate_base: {          3: 12.6 }, image: "img/6b33d4fa539d5adb.jpg", name: "010" }
-    ,321: { rate_base: {          3: 12.5 }, image: "img/40cc7a6a264f88c1.jpg", name: "ERIS -Legend of Gaidelia-" }
-    ,322: { rate_base: {          3: 13.6 }, image: "img/8b145fe4cf0c01bb.jpg", name: "Imperishable Night 2006 (2016 Refine)" }
-    ,323: { rate_base: {          3: 13.5 }, image: "img/282cb1cacd4c1bb4.jpg", name: "Dreadnought" }
-    ,324: { rate_base: {          3: 12.6 }, image: "img/d51d4ffba9f8d45e.jpg", name: "STAGER" }
-    ,325: { rate_base: {          3: 12.6 }, image: "img/97eca622afca0f15.jpg", name: "Her Majesty" }
-    ,326: { rate_base: {          3: 12.5 }, image: "img/fd01fc38e38042e3.jpg", name: "Sakura Fubuki" }
-    ,327: { rate_base: {          3: 12.7 }, image: "img/17c363c1fd2fa7d1.jpg", name: "JULIAN" }
-    ,329: { rate_base: {          3: 12.3 }, image: "img/e869980ddd2f9c68.jpg", name: "STAIRWAY TO GENERATION" }
-    ,330: { rate_base: {          3: 12.1 }, image: "img/b3ea0fe012eb7ea2.jpg", name: "ドキドキDREAM!!!" }
-    ,331: { rate_base: {          3: 12.2 }, image: "img/ec37e447b91995dd.jpg", name: "猛進ソリストライフ！" }
-    ,332: { rate_base: {          3: 12.3 }, image: "img/41001ddd4214d6b6.jpg", name: "空威張りビヘイビア" }
-    ,336: { rate_base: {          3: 12.0 }, image: "img/e40fceaa1bb587b7.jpg", name: "シジョウノコエ VOCALO ver." }
+var DIFFICULTY = {
+     003: { rate_base: {          3: 11.8 }, image: "img/d739ba44da6798a0.jpg" } // B.B.K.K.B.K.K.
+    ,005: { rate_base: {          3: 11.3 }, image: "img/38faf81803b730f3.jpg" } // Scatman (Ski Ba Bop Ba Dop Bop)
+    ,006: { rate_base: {          3: 12.3 }, image: "img/90589be457544570.jpg" } // Reach for the Stars
+    ,007: { rate_base: { 2: 12.0, 3: 13.6 }, image: "img/b602913a68fca621.jpg" } // 初音ミクの消失
+    ,009: { rate_base: {          3: 11.3 }, image: "img/fce0bad9123dcd76.jpg" } // 情熱大陸
+    ,010: { rate_base: {          3: 11.7 }, image: "img/0d7bd146ebed6fba.jpg" } // All I Want
+    ,014: { rate_base: {          3: 11.0 }, image: "img/af78dd039a36a4c7.jpg" } // コネクト
+    ,017: { rate_base: {          3: 11.1 }, image: "img/696d4f956ebb4209.jpg" } // 空色デイズ
+    ,018: { rate_base: {          3: 11.2 }, image: "img/3c2606abe4dded71.jpg" } // 千本桜
+    ,019: { rate_base: {          3: 13.2 }, image: "img/0b98b8b4e7cfd997.jpg" } // DRAGONLADY
+    ,021: { rate_base: {          3: 11.9 }, image: "img/4f69fb126f579c2f.jpg" } // ナイト・オブ・ナイツ
+    ,023: { rate_base: {          3: 12.1 }, image: "img/b8ab9573859ebe4f.jpg" } // 一触即発☆禅ガール
+    ,027: { rate_base: {          3: 12.5 }, image: "img/fdc3bb451f6403d2.jpg" } // タイガーランペイジ
+    ,033: { rate_base: {          3: 13.0 }, image: "img/fddc37caee47286d.jpg" } // Blue Noise
+    ,035: { rate_base: {          3: 12.4 }, image: "img/aabf49add818546d.jpg" } // Lapis
+    ,036: { rate_base: {          3: 11.0 }, image: "img/e273c9d64170b575.jpg" } // 届かない恋 '13
+    ,037: { rate_base: {          3: 11.3 }, image: "img/335dbb14cedb70bf.jpg" } // 鳥の詩
+    ,038: { rate_base: {          3: 11.0 }, image: "img/529d98ad07709ae5.jpg" } // 天ノ弱
+    ,041: { rate_base: {          3: 11.6 }, image: "img/7f17441bc2582ec8.jpg" } // sweet little sister
+    ,042: { rate_base: {          3: 11.6 }, image: "img/4bbc4ec5ee9aa0b6.jpg" } // oath sign
+    ,045: { rate_base: {          3: 12.2 }, image: "img/90dca26c66c5d5b7.jpg" } // L9
+    ,047: { rate_base: {          3: 12.0 }, image: "img/5cb17a59f4b8c133.jpg" } // 六兆年と一夜物語
+    ,048: { rate_base: {          3: 11.8 }, image: "img/b38eba298df2c6db.jpg" } // Unlimited Spark!
+    ,051: { rate_base: {          3: 12.7 }, image: "img/161f13a787a00032.jpg" } // My First Phone
+    ,052: { rate_base: { 2: 11.1, 3: 13.2 }, image: "img/a62f975edc860e34.jpg" } // Cyberozar
+    ,053: { rate_base: {          3: 12.3 }, image: "img/73ad66e81061bba3.jpg" } // Teriqma
+    ,055: { rate_base: {          3: 11.2 }, image: "img/506f053a80e1b28e.jpg" } // 夏祭り
+    ,056: { rate_base: {          3: 11.0 }, image: "img/2535487ae13b2fd8.jpg" } // そばかす
+    ,060: { rate_base: {          3: 11.3 }, image: "img/3bee1cce7d794f31.jpg" } // only my railgun
+    ,061: { rate_base: { 2: 11.0, 3: 13.5 }, image: "img/2ccf97477eaf45ad.jpg" } // GOLDEN RULE
+    ,062: { rate_base: {          3: 12.4 }, image: "img/9386971505bb20b0.jpg" } // 名も無い鳥
+    ,063: { rate_base: { 2: 11.7, 3: 13.1 }, image: "img/2df15f390356067f.jpg" } // Gate of Fate
+    ,064: { rate_base: {          3: 12.7 }, image: "img/6bf934fede23724d.jpg" } // 今ぞ♡崇め奉れ☆オマエらよ！！～姫の秘メタル渇望～
+    ,065: { rate_base: {          3: 11.1 }, image: "img/713d52aa40ed7fc4.jpg" } // Anemone
+    ,066: { rate_base: {          3: 12.3 }, image: "img/c22702914849a11a.jpg" } // 明るい未来
+    ,067: { rate_base: {          3: 11.2 }, image: "img/11437ebc94947550.jpg" } // 昵懇レファレンス
+    ,068: { rate_base: {          3: 11.7 }, image: "img/145b9b6f4c27d78e.jpg" } // 乗り切れ受験ウォーズ
+    ,069: { rate_base: { 2: 11.9, 3: 13.3 }, image: "img/c2c4ece2034eb620.jpg" } // The wheel to the right
+    ,070: { rate_base: {          3: 12.4 }, image: "img/3ccebd87235f591c.jpg" } // STAR
+    ,071: { rate_base: {          3: 12.3 }, image: "img/2bf02bef3051ecaf.jpg" } // Infantoon Fantasy
+    ,072: { rate_base: {          3: 13.5 }, image: "img/ec3a366b4724f8f6.jpg" } // Genesis
+    ,073: { rate_base: {          3: 12.6 }, image: "img/0c2791f737ce1ff2.jpg" } // MUSIC PЯAYER
+    ,074: { rate_base: {          3: 11.0 }, image: "img/feef37ed3d91cfbd.jpg" } // リリーシア
+    ,075: { rate_base: {          3: 11.7 }, image: "img/e1454dc2eeae2030.jpg" } // Counselor
+    ,076: { rate_base: { 2: 11.8, 3: 13.4 }, image: "img/93abb77776c70b47.jpg" } // luna blu
+    ,077: { rate_base: {          3: 12.8 }, image: "img/01fc7f761272bfb4.jpg" } // ケモノガル
+    ,079: { rate_base: {          3: 11.0 }, image: "img/281f821a06a7da18.jpg" } // ＧＯ！ＧＯ！ラブリズム♥
+    ,082: { rate_base: {          3: 12.5 }, image: "img/27ef71f8a76f1e8a.jpg" } // Memories of Sun and Moon
+    ,083: { rate_base: {          3: 12.2 }, image: "img/181682bf5b277726.jpg" } // ロストワンの号哭
+    ,088: { rate_base: {          3: 12.1 }, image: "img/c4223e68340efa41.jpg" } // The Concept of Love
+    ,090: { rate_base: { 2: 11.6, 3: 13.2 }, image: "img/19d57f9a7652308a.jpg" } // L'épisode
+    ,091: { rate_base: {          3: 11.2 }, image: "img/cb77a66b62023890.jpg" } // Yet Another ”drizzly rain”
+    ,092: { rate_base: {          3: 12.8 }, image: "img/17315fb464f265bd.jpg" } // 最終鬼畜妹・一部声
+    ,093: { rate_base: {          3: 12.3 }, image: "img/6b40809324937ec9.jpg" } // 蒼空に舞え、墨染の桜
+    ,094: { rate_base: {          3: 12.3 }, image: "img/164258c65c714d50.jpg" } // セツナトリップ
+    ,095: { rate_base: {          3: 12.1 }, image: "img/db38c119e4d8933e.jpg" } // 砂漠のハンティングガール♡
+    ,096: { rate_base: {          3: 11.8 }, image: "img/9d2ebc847487e01b.jpg" } // チルノのパーフェクトさんすう教室
+    ,098: { rate_base: {          3: 11.4 }, image: "img/f7e67efaf6ced6ea.jpg" } // 魔理沙は大変なものを盗んでいきました
+    ,099: { rate_base: {          3: 11.7 }, image: "img/ee332e6fa86661fd.jpg" } // 言ノ葉カルマ
+    ,101: { rate_base: {          3: 12.9 }, image: "img/81e347d3b96b2ae1.jpg" } // Tango Rouge
+    ,102: { rate_base: {          3: 12.5 }, image: "img/7fc6ae1b488b88de.jpg" } // Tuning Rangers
+    ,103: { rate_base: { 2: 11.7, 3: 13.7 }, image: "img/3210d321c2700a57.jpg" } // エンドマークに希望と涙を添えて
+    ,104: { rate_base: {          3: 12.5 }, image: "img/ff945c9cb9e43e83.jpg" } // とーきょー全域★アキハバラ？
+    ,106: { rate_base: { 2: 12.2, 3: 13.8 }, image: "img/8219519cc94d5524.jpg" } // 宛城、炎上！！
+    ,107: { rate_base: {          3: 13.0 }, image: "img/b43fef626f5b88cd.jpg" } // We Gonna Journey
+    ,108: { rate_base: {          3: 12.0 }, image: "img/1ec3213366f4ad57.jpg" } // The ether
+    ,110: { rate_base: {          3: 11.2 }, image: "img/d42200159ef91521.jpg" } // Magia
+    ,111: { rate_base: {          3: 11.3 }, image: "img/7ad659a57ef26888.jpg" } // staple stable
+    ,112: { rate_base: {          3: 11.0 }, image: "img/3dc05a281c0724f7.jpg" } // マジLOVE1000%
+    ,113: { rate_base: {          3: 11.4 }, image: "img/3f8eb68a4f6089dc.jpg" } // ストリーミングハート
+    ,114: { rate_base: {          3: 11.4 }, image: "img/b02c3912d1524d5c.jpg" } // Sweet Devil
+    ,115: { rate_base: {          3: 11.5 }, image: "img/9165ee58223accc0.jpg" } // Dreaming
+    ,117: { rate_base: {          3: 11.5 }, image: "img/88124d980ac7eca4.jpg" } // M.S.S.Planet
+    ,118: { rate_base: {          3: 12.0 }, image: "img/17e485acfe11a67f.jpg" } // 腐れ外道とチョコレゐト
+    ,119: { rate_base: {          3: 12.3 }, image: "img/a7dd6716fcae0cb8.jpg" } // アウターサイエンス
+    ,120: { rate_base: {          3: 12.7 }, image: "img/a84a31e562efd7a0.jpg" } // 四次元跳躍機関
+    ,121: { rate_base: {          3: 12.5 }, image: "img/4196f71ce51620a0.jpg" } // 東方妖々夢 ～the maximum moving about～
+    ,122: { rate_base: {          3: 12.5 }, image: "img/67418ba28151c3ff.jpg" } // 少女幻葬戦慄曲　～　Necro Fantasia
+    ,124: { rate_base: {          3: 12.5 }, image: "img/74ce2f0a4b4f6fe2.jpg" } // 夏影
+    ,126: { rate_base: {          3: 11.3 }, image: "img/547ba5407b6e7fa0.jpg" } // Heart To Heart
+    ,128: { rate_base: {          3: 12.7 }, image: "img/7edc6879319accfd.jpg" } // The Formula
+    ,129: { rate_base: {          3: 11.2 }, image: "img/f56cd36303a3239a.jpg" } // Hacking to the Gate
+    ,130: { rate_base: {          3: 11.7 }, image: "img/e4df0d48302ccd26.jpg" } // スカイクラッドの観測者
+    ,131: { rate_base: {          3: 12.6 }, image: "img/38d3c5a5a45c6d07.jpg" } // チルドレンレコード
+    ,132: { rate_base: {          3: 12.2 }, image: "img/1c508bbd42d335fe.jpg" } // イカサマライフゲイム
+    ,134: { rate_base: { 2: 11.8, 3: 13.7 }, image: "img/08a24ed249ed2eec.jpg" } // HAELEQUIN (Original Remaster)
+    ,135: { rate_base: {          3: 13.5 }, image: "img/e7ee14d9fe63d072.jpg" } // Vallista
+    ,136: { rate_base: {          3: 12.5 }, image: "img/c4f977d264deafb1.jpg" } // Äventyr
+    ,137: { rate_base: {          3: 13.6 }, image: "img/13a5a9ca35a9b71b.jpg" } // Angel dust
+    ,138: { rate_base: {          3: 13.0 }, image: "img/478e8835e382f740.jpg" } // conflict
+    ,140: { rate_base: {          3: 11.9 }, image: "img/0aad2e0ff661e7d1.jpg" } // Guilty
+    ,141: { rate_base: { 2: 11.5, 3: 13.3 }, image: "img/2e6c11edba79d997.jpg" } // 閃鋼のブリューナク
+    ,142: { rate_base: {          3: 12.6 }, image: "img/a8d181c5442df7d2.jpg" } // Altale
+    ,144: { rate_base: {          3: 13.3 }, image: "img/8b04b9ad2d49850c.jpg" } // Aragami
+    ,145: { rate_base: {          3: 11.8 }, image: "img/0bb58f15b16703ab.jpg" } // Change Our MIRAI！
+    ,146: { rate_base: {          3: 11.7 }, image: "img/d3b40f7b8e0758ff.jpg" } // 夕暮れワンルーム
+    ,148: { rate_base: {          3: 11.0 }, image: "img/cd458a75aa049889.jpg" } // Theme of SeelischTact
+    ,149: { rate_base: {          3: 11.7 }, image: "img/c9c2fa20dcd9a46e.jpg" } // 緋色のDance
+    ,150: { rate_base: {          3: 11.8 }, image: "img/2a41ad71b77d12c9.jpg" } // brilliant better
+    ,151: { rate_base: {          3: 12.5 }, image: "img/7237488215dbd1d3.jpg" } // Alma
+    ,152: { rate_base: { 2: 11.7, 3: 13.0 }, image: "img/f63fab30a7b6f160.jpg" } // Gustav Battle
+    ,154: { rate_base: {          3: 12.7 }, image: "img/2e9fdbbc15ade5cb.jpg" } // SAVIOR OF SONG
+    ,156: { rate_base: {          3: 11.5 }, image: "img/b33923bd4e6e5609.jpg" } // FREELY TOMORROW
+    ,157: { rate_base: {          3: 12.8 }, image: "img/573109ca9050f55d.jpg" } // ギガンティック O.T.N
+    ,158: { rate_base: {          3: 11.0 }, image: "img/e3ce6712e8cddf10.jpg" } // フォルテシモBELL
+    ,159: { rate_base: {          3: 13.3 }, image: "img/d5a47266b4fe0bfe.jpg" } // ジングルベル
+    ,160: { rate_base: {          3: 11.5 }, image: "img/809bf2b3f8effa6f.jpg" } // 言ノ葉遊戯
+    ,161: { rate_base: {          3: 12.4 }, image: "img/4ceb5aed4a4a1c47.jpg" } // 私の中の幻想的世界観及びその顕現を想起させたある現実での出来事に関する一考察
+    ,163: { rate_base: {          3: 11.3 }, image: "img/fd6847e3bb2e3629.jpg" } // 幾四音-Ixion-
+    ,165: { rate_base: {          3: 12.8 }, image: "img/1e85c4b6775c84b0.jpg" } // ぼくらの16bit戦争
+    ,166: { rate_base: {          3: 11.8 }, image: "img/5a0ac8501e3b95ce.jpg" } // 裏表ラバーズ
+    ,167: { rate_base: {          3: 12.7 }, image: "img/24611f2e2374e6a8.jpg" } // 脳漿炸裂ガール
+    ,168: { rate_base: {          3: 11.9 }, image: "img/1982767436fc52d8.jpg" } // ネトゲ廃人シュプレヒコール
+    ,169: { rate_base: {          3: 11.4 }, image: "img/f092ddd9e1fe088b.jpg" } // elegante
+    ,171: { rate_base: {          3: 12.3 }, image: "img/25abef88cb12af3e.jpg" } // XL TECHNO
+    ,173: { rate_base: {          3: 13.1 }, image: "img/2e95529be9118a11.jpg" } // Halcyon
+    ,176: { rate_base: {          3: 11.3 }, image: "img/aa0cefb5a0f00457.jpg" } // Dance!
+    ,177: { rate_base: {          3: 12.6 }, image: "img/6e7843f9d831b0ac.jpg" } // Jimang Shot
+    ,178: { rate_base: {          3: 12.7 }, image: "img/9f281db3bcc9353b.jpg" } // stella=steLLa
+    ,179: { rate_base: {          3: 11.1 }, image: "img/0e73189a7083e4f4.jpg" } // すろぉもぉしょん
+    ,180: { rate_base: { 2: 12.4, 3: 13.9 }, image: "img/a732d43fd2a11e8f.jpg" } // 怒槌
+    ,185: { rate_base: {          3: 11.2 }, image: "img/520c1fef62954ca6.jpg" } // 楽園の翼
+    ,187: { rate_base: {          3: 13.2 }, image: "img/e6642a96885723c1.jpg" } // 患部で止まってすぐ溶ける～狂気の優曇華院
+    ,189: { rate_base: {          3: 12.7 }, image: "img/9310d07b7e02e73a.jpg" } // ひれ伏せ愚民どもっ！
+    ,190: { rate_base: {          3: 12.6 }, image: "img/bbaa464731ab96a4.jpg" } // エテルニタス・ルドロジー
+    ,196: { rate_base: { 2: 11.9, 3: 13.7 }, image: "img/ed40032f25177518.jpg" } // FREEDOM DiVE
+    ,197: { rate_base: { 2: 11.2, 3: 13.1 }, image: "img/ae6d3a8806e09613.jpg" } // Jack-the-Ripper◆
+    ,199: { rate_base: {          3: 12.1 }, image: "img/d76afb63de1417f8.jpg" } // ハート・ビート
+    ,200: { rate_base: {          3: 12.1 }, image: "img/569e7b07c0696bc7.jpg" } // 無敵We are one!!
+    ,201: { rate_base: { 2: 12.4, 3: 13.9 }, image: "img/a251c24a3cc4dbf7.jpg" } // Contrapasso -inferno-
+    ,202: { rate_base: { 2: 11.2, 3: 13.1 }, image: "img/45112e2818cf80a2.jpg" } // GEMINI -C-
+    ,203: { rate_base: {          3: 12.0 }, image: "img/101d4e7b03a5a89e.jpg" } // FLOWER
+    ,204: { rate_base: {          3: 11.0 }, image: "img/1ea73ffbba6d7ead.jpg" } // ちくわパフェだよ☆CKP
+    ,205: { rate_base: {          3: 12.7 }, image: "img/3d7803669dd3fcb9.jpg" } // SNIPE WHOLE
+    ,206: { rate_base: {          3: 11.4 }, image: "img/e10bbd173df15772.jpg" } // Signs Of Love (“Never More” ver.)
+    ,207: { rate_base: {          3: 11.7 }, image: "img/5151993f923b06a5.jpg" } // Your Affection (Daisuke Asakura Remix)
+    ,208: { rate_base: {          3: 12.7 }, image: "img/5bab1a38b98d59b5.jpg" } // SAMBISTA
+    ,209: { rate_base: {          3: 11.7 }, image: "img/5744f4cf66710a56.jpg" } // 君色シグナル
+    ,210: { rate_base: {          3: 12.4 }, image: "img/040cd43234aed57a.jpg" } // アスノヨゾラ哨戒班
+    ,211: { rate_base: {          3: 12.2 }, image: "img/d99079fecaa936ab.jpg" } // 天樂
+    ,212: { rate_base: {          3: 12.1 }, image: "img/1ee29f73ee8f53d0.jpg" } // いろは唄
+    ,213: { rate_base: {          3: 11.9 }, image: "img/c6d494f528391d1c.jpg" } // 星屑ユートピア
+    ,214: { rate_base: {          3: 11.9 }, image: "img/f4a2d88c38669f72.jpg" } // 青春はNon-Stop!
+    ,215: { rate_base: {          3: 12.4 }, image: "img/81cc90c04676f18b.jpg" } // Falling Roses
+    ,216: { rate_base: {          3: 12.3 }, image: "img/3227722a8345a950.jpg" } // 放課後革命
+    ,217: { rate_base: {          3: 11.8 }, image: "img/2b3c90b1dab1ecff.jpg" } // 楽園ファンファーレ
+    ,219: { rate_base: { 2: 12.7, 3: 13.9 }, image: "img/246f63902c4b0f89.jpg" } // 玩具狂奏曲 -終焉-
+    ,220: { rate_base: {          3: 12.3 }, image: "img/c3041fd82b0a0710.jpg" } // 如月アテンション
+    ,222: { rate_base: {          3: 12.9 }, image: "img/ad33a423c865bed1.jpg" } // Mr. Wonderland
+    ,223: { rate_base: { 2: 11.0, 3: 13.0 }, image: "img/8ec9a26e11ec1a40.jpg" } // カミサマネジマキ
+    ,224: { rate_base: {          3: 11.1 }, image: "img/b9d170f84c1bb5d3.jpg" } // 恋愛裁判
+    ,225: { rate_base: {          3: 12.1 }, image: "img/6f86e2a47e9a283c.jpg" } // ウミユリ海底譚
+    ,226: { rate_base: { 2: 12.3, 3: 13.8 }, image: "img/993b5cddb9d9badf.jpg" } // Garakuta Doll Play
+    ,227: { rate_base: {          3: 11.5 }, image: "img/74c77deb2f2e5e07.jpg" } // 洗脳
+    ,228: { rate_base: {          3: 12.0 }, image: "img/882be51fe439614d.jpg" } // このふざけた素晴らしき世界は、僕の為にある
+    ,229: { rate_base: { 2: 11.9, 3: 13.4 }, image: "img/73f86aec8d6c7c9b.jpg" } // 紅華刑
+    ,230: { rate_base: {          3: 12.4 }, image: "img/b59d2b2ab877a77d.jpg" } // Hyperion
+    ,232: { rate_base: { 2: 11.3, 3: 13.4 }, image: "img/a2069fdb9d860d36.jpg" } // Elemental Creation
+    ,233: { rate_base: {          3: 12.2 }, image: "img/5fe5db1d2e40ee7a.jpg" } // アルストロメリア
+    ,235: { rate_base: {          3: 12.5 }, image: "img/8b84b06033585428.jpg" } // ファッとして桃源郷
+    ,238: { rate_base: {          3: 11.9 }, image: "img/4c769ae611f83d21.jpg" } // フレンズ
+    ,240: { rate_base: {          3: 12.6 }, image: "img/47397105bad447fb.jpg" } // 夜咄ディセイブ
+    ,243: { rate_base: {          3: 12.2 }, image: "img/8872c759bea3bd9f.jpg" } // シュガーソングとビターステップ
+    ,244: { rate_base: {          3: 12.3 }, image: "img/e0a700914896ea4a.jpg" } // 回レ！雪月花
+    ,245: { rate_base: {          3: 11.4 }, image: "img/630ac5b31e8ab816.jpg" } // Help me, あーりん！
+    ,246: { rate_base: {          3: 12.7 }, image: "img/d445e4878a818d8b.jpg" } // なるとなぎのパーフェクトロックンロール教室
+    ,247: { rate_base: {          3: 11.9 }, image: "img/58847f9694837c0b.jpg" } // 絶世スターゲイト
+    ,248: { rate_base: { 2: 12.3, 3: 13.9 }, image: "img/a2fdef9e4b278a51.jpg" } // Schrecklicher Aufstand
+    ,250: { rate_base: { 2: 11.8, 3: 13.5 }, image: "img/989f4458fb34aa9d.jpg" } // Philosopher
+    ,251: { rate_base: {          3: 12.5 }, image: "img/457722c9f3ff5473.jpg" } // Crazy ∞ nighT
+    ,252: { rate_base: {          3: 12.3 }, image: "img/bb221e3de960de7d.jpg" } // 愛迷エレジー
+    ,254: { rate_base: {          3: 11.7 }, image: "img/2e617d713547fe84.jpg" } // その群青が愛しかったようだった
+    ,255: { rate_base: {          3: 11.1 }, image: "img/429d34fef5fddb02.jpg" } // 激情！ミルキィ大作戦
+    ,257: { rate_base: {          3: 13.0 }, image: "img/bef9b79c637bf4c9.jpg" } // BOKUTO
+    ,259: { rate_base: { 2: 11.3, 3: 13.1 }, image: "img/4d66e5d1669d79a2.jpg" } // Oshama Scramble! (Cranky Remix)
+    ,260: { rate_base: {          3: 12.4 }, image: "img/03f1dafe3b08607e.jpg" } // D.E.A.D.L.Y.
+    ,261: { rate_base: {          3: 12.3 }, image: "img/6e917606db3c5a0e.jpg" } // ロボットプラネットユートピア
+    ,262: { rate_base: {          3: 13.6 }, image: "img/676e59847912f5ca.jpg" } // Tidal Wave
+    ,263: { rate_base: {          3: 11.7 }, image: "img/015358a0c0580022.jpg" } // Hand in Hand
+    ,264: { rate_base: {          3: 12.2 }, image: "img/f44c6b628889f8ec.jpg" } // My Dearest Song
+    ,267: { rate_base: {          3: 11.5 }, image: "img/a0d03551eb3930e9.jpg" } // 心象蜃気楼
+    ,270: { rate_base: {          3: 12.3 }, image: "img/21dfcd3ae2c5c370.jpg" } // エンヴィキャットウォーク
+    ,273: { rate_base: {          3: 11.8 }, image: "img/604157e2c49d91d7.jpg" } // ビバハピ
+    ,276: { rate_base: {          3: 12.4 }, image: "img/82105b37d18450b6.jpg" } // 後夜祭
+    ,278: { rate_base: {          3: 11.4 }, image: "img/5f1d7a520a2735d4.jpg" } // からくりピエロ
+    ,279: { rate_base: {          3: 11.7 }, image: "img/84ecaebe6bce2a58.jpg" } // 深海少女
+    ,281: { rate_base: {          3: 13.4 }, image: "img/330e57eeeb0fb2cd.jpg" } // ラクガキスト
+    ,286: { rate_base: {          3: 11.5 }, image: "img/afcce0c85c1f8610.jpg" } // Tell Your World
+    ,287: { rate_base: {          3: 11.9 }, image: "img/5febf5df2b5094f3.jpg" } // ロミオとシンデレラ
+    ,288: { rate_base: {          3: 11.6 }, image: "img/f29f10a963df60cf.jpg" } // First Twinkle
+    ,289: { rate_base: {          3: 12.7 }, image: "img/0cece587cced4d3f.jpg" } // ウソラセラ
+    ,290: { rate_base: {          3: 11.3 }, image: "img/b1d08379f05c706e.jpg" } // 檄!帝国華撃団
+    ,291: { rate_base: {          3: 12.4 }, image: "img/9c5e71b3588dbc70.jpg" } // Kronos
+    ,292: { rate_base: {          3: 12.0 }, image: "img/b12c25f87b1d036e.jpg" } // 月に叢雲華に風
+    ,293: { rate_base: {          3: 13.2 }, image: "img/c58227eb0d14938c.jpg" } // インビジブル
+    ,296: { rate_base: {          3: 12.1 }, image: "img/76535cf4c728f2af.jpg" } // かくしん的☆めたまるふぉ～ぜっ!
+    ,298: { rate_base: {          3: 12.6 }, image: "img/7c649691aa0c4b3d.jpg" } // PRIVATE SERVICE
+    ,299: { rate_base: {          3: 11.4 }, image: "img/9bd44690db5375ac.jpg" } // secret base ～君がくれたもの～ (10 years after Ver.)
+    ,300: { rate_base: {          3: 12.2 }, image: "img/012eb1ed09577836.jpg" } // No Routine
+    ,304: { rate_base: {          3: 11.7 }, image: "img/16cb8567115a2f2c.jpg" } // In The Blue Sky ’01
+    ,305: { rate_base: { 2: 11.0, 3: 13.3 }, image: "img/266bd38219201fa1.jpg" } // 幻想のサテライト
+    ,306: { rate_base: {          3: 12.2 }, image: "img/106d9eec68ed84b3.jpg" } // 凛として咲く花の如く
+    ,307: { rate_base: {          3: 12.7 }, image: "img/ff9f70c8c0d9f24e.jpg" } // Paqqin
+    ,308: { rate_base: {          3: 11.9 }, image: "img/f8d3f2e57ae2ff24.jpg" } // fake!fake!
+    ,309: { rate_base: {          3: 12.5 }, image: "img/cee51d69c428f8f5.jpg" } // Rising Hope
+    ,313: { rate_base: {          3: 11.4 }, image: "img/5ac018495d6f01a5.jpg" } // ひだまりデイズ
+    ,316: { rate_base: {          3: 11.5 }, image: "img/88f9536c08cb4e3f.jpg" } // みくみくにしてあげる♪【してやんよ】
+    ,317: { rate_base: {          3: 13.4 }, image: "img/db15d5b7aefaa672.jpg" } // Air
+    ,318: { rate_base: {          3: 13.1 }, image: "img/f803d578eb4047eb.jpg" } // DataErr0r
+    ,319: { rate_base: {          3: 12.6 }, image: "img/e9eeb98572b140bc.jpg" } // Say A Vengeance
+    ,320: { rate_base: {          3: 12.6 }, image: "img/6b33d4fa539d5adb.jpg" } // 010
+    ,321: { rate_base: {          3: 12.5 }, image: "img/40cc7a6a264f88c1.jpg" } // ERIS -Legend of Gaidelia-
+    ,322: { rate_base: {          3: 13.6 }, image: "img/8b145fe4cf0c01bb.jpg" } // Imperishable Night 2006 (2016 Refine)
+    ,323: { rate_base: {          3: 13.5 }, image: "img/282cb1cacd4c1bb4.jpg" } // Dreadnought
+    ,324: { rate_base: {          3: 12.6 }, image: "img/d51d4ffba9f8d45e.jpg" } // STAGER
+    ,325: { rate_base: {          3: 12.6 }, image: "img/97eca622afca0f15.jpg" } // Her Majesty
+    ,326: { rate_base: {          3: 12.5 }, image: "img/fd01fc38e38042e3.jpg" } // Sakura Fubuki
+    ,327: { rate_base: {          3: 12.7 }, image: "img/17c363c1fd2fa7d1.jpg" } // JULIAN
+    ,329: { rate_base: {          3: 12.3 }, image: "img/e869980ddd2f9c68.jpg" } // STAIRWAY TO GENERATION
+    ,330: { rate_base: {          3: 12.1 }, image: "img/b3ea0fe012eb7ea2.jpg" } // ドキドキDREAM!!!
+    ,331: { rate_base: {          3: 12.2 }, image: "img/ec37e447b91995dd.jpg" } // 猛進ソリストライフ！
+    ,332: { rate_base: {          3: 12.3 }, image: "img/41001ddd4214d6b6.jpg" } // 空威張りビヘイビア
+    ,336: { rate_base: {          3: 12.0 }, image: "img/e40fceaa1bb587b7.jpg" } // シジョウノコエ VOCALO ver.
 };
 
 // ---- API wrappers
@@ -400,6 +400,9 @@ function dom(template, params)
 // -----------------------------------------------------------------------------
 // global vars
 // -----------------------------------------------------------------------------
+
+// name vs details map
+var music_info = {};
 
 // current values
 var disp_rate         = 0;
@@ -626,12 +629,13 @@ $("#cra_wrapper").delay(400).fadeIn(400);
 // -----------------------------------------------------------------------------
 
 // Create playlog entity if MUSIC_INFO exists. Otherwise return null.
-function playlog(id, level, score, play_date /* optional */) {
-    var info = MUSIC_INFO[id];
+function playlog(name, level, score, play_date /* optional */) {
+    var info = music_info[name];
     var rate_base  = info && info.rate_base[level];
     if (!rate_base) return null;
     return {
-        id:        id,
+        name:      name,
+        image:     info.image,
         level:     level,
         score:     score,
         rate:      score_to_rate(rate_base, score),
@@ -684,7 +688,7 @@ function fetch_playlog(callback)
         var last_play_date = recent_candidates[0] && recent_candidates[recent_candidates.length - 1].play_date;
         for (var i = d.userPlaylogList.length - 1; i >= 0; i--) {
             var log = playlog(
-                d.userPlaylogList[i].musicId,
+                d.userPlaylogList[i].musicName,
                 LEVEL_ID[d.userPlaylogList[i].levelName],
                 d.userPlaylogList[i].score,
                 d.userPlaylogList[i].userPlayDate
@@ -698,16 +702,20 @@ function fetch_playlog(callback)
     });
 }
 
-// use GetUserMusicApi to fetch all scores, and update chart_list
+// use GetUserMusicApi to fetch all scores, then update music_info and
+// chart_list
 function fetch_score_data(level, callback)
 {
     $("#cra_window_inner").html("<p>loading ...</p>");
     request_api("GetUserMusicApi", {
         level: "1990" + level
     }, function(d) {
+        Object.keys(d.musicNameMap).map(function (id) {
+            music_info[d.musicNameMap[id]] = DIFFICULTY[id];
+        });
         for (var i = 0; i < d.userMusicList.length; i++) {
             var log = playlog(
-                d.userMusicList[i].musicId,
+                d.musicNameMap[d.userMusicList[i].musicId],
                 level,
                 d.userMusicList[i].scoreMax
             );
@@ -1281,14 +1289,12 @@ function render_chart_list(list, msgs)
         var $list_item = $("<div class='frame02 w400 cra_chart_list_item'>")
             .appendTo("#cra_chart_list");
 
-        var info = MUSIC_INFO[list[i].id];
-
         $list_item
             .html(`
 <div class="play_jacket_side">
   <div class="play_jacket_area">
     <div id="Jacket" class="play_jacket_img">
-      <img src=${info.image}>
+      <img src=${list[i].image}>
     </div>
   </div>
 </div>
@@ -1303,7 +1309,7 @@ function render_chart_list(list, msgs)
   </div>
   <div class="box02 play_musicdata_block">
     <div id="MusicTitle" class="play_musicdata_title">
-      ${info.name}
+      ${list[i].name}
     </div>
     <div class="play_musicdata_score clearfix">
       <div class="play_musicdata_score_text">

--- a/chunithm.js
+++ b/chunithm.js
@@ -484,6 +484,12 @@ var the_css = {
         "background-color": "black", "color": "white"
     },
 
+    '#cra_offer_playlog': {
+        "position": "static", "font-size": "10px",
+        "vertical-align": "top", "margin": "0 0 0 5px",
+        "padding": "2px 5px", "border-radius": "4px"
+    },
+
     ".cra_chart_list_item": {
         "text-align": "center",
     },
@@ -1152,6 +1158,7 @@ function rate_display()
     </div>
   </div>
   <a id="cra_share_button" class="twitter-share-button"></a>
+  <div id='cra_offer_playlog' class="cra_sort_button">データ提供</div>
 </div>`);
 
         $("#cra_share_button")
@@ -1168,14 +1175,19 @@ function rate_display()
                   " (" + best_list[0].name + ") #CHUNITHMRateAnalyzer")
             .html("Tweet");
 
+        $("#cra_offer_playlog").click(function () {
+            if (window.confirm('Recent 枠の解析をされている @max_eipi さんにプレー履歴を提供し、解析に協力することができます。ユーザー名等は送信されません。提供する場合は OK をクリックしてください。')) {
+                offer_playlog();
+            }
+        });
+
         $("#cra_sort_menu")
             .html("<div id='cra_sort_rate' class='cra_sort_button'>レート順</div>" +
                   "<div id='cra_sort_base' class='cra_sort_button'>難易度順</div>" +
                   "<div id='cra_sort_score' class='cra_sort_button'>スコア順</div>" +
                   "<div id='cra_sort_score_req' class='cra_sort_button'>必要スコア順</div>" +
                   "<div id='cra_sort_score_ave' class='cra_sort_button'>おすすめ(β)</div>" +
-                  "<div id='cra_recent_list' class='cra_sort_button'>Recent枠(β)</div>" +
-                  "<div id='cra_offer_playlog' class='cra_sort_button'>プレイデータ提供</div>");
+                  "<div id='cra_recent_list' class='cra_sort_button'>Recent枠(β)</div>");
 
         $("#cra_footer")
             .html("CHUNITHM Rate Analyzer by zk_phi " +
@@ -1245,10 +1257,6 @@ function rate_display()
         $("#cra_recent_list").click(function () {
             recent_candidates.sort(comp_rate);
             render_chart_list(recent_candidates, { 0: 'Recent枠', 10: 'Recent候補枠' });
-        });
-
-        $("#cra_offer_playlog").click(function () {
-            offer_playlog();
         });
 
         // load twitter buttons

--- a/chunithm.js
+++ b/chunithm.js
@@ -669,7 +669,7 @@ function push_playlog_to_recent_candidates (log) {
         else {
             for (var k = 0; k < recent_candidates.length; k++) {
                 if (recent_candidates[k].rate < log.rate) {
-                    if (len >= 30) recent_candidates.splice(k, 1);
+                    recent_candidates.splice(k, 1);
                     recent_candidates.push(log);
                     break;
                 }

--- a/chunithm.js
+++ b/chunithm.js
@@ -1149,6 +1149,7 @@ function rate_display()
                   "<div id='cra_sort_score' class='cra_sort_button'>スコア順</div>" +
                   "<div id='cra_sort_score_req' class='cra_sort_button'>必要スコア順</div>" +
                   "<div id='cra_sort_score_ave' class='cra_sort_button'>おすすめ(β)</div>" +
+                  "<div id='cra_recent_list' class='cra_sort_button'>Recent枠(β)</div>" +
                   "<div id='cra_manage_play_data' class='cra_sort_button'>プレイデータ管理</div>");
 
         $("#cra_footer")
@@ -1214,6 +1215,14 @@ function rate_display()
             indices[0] = "おすすめ"
             indices[i] = "おすすめここまで"
             render_chart_list(indices);
+        });
+
+        $("#cra_recent_list").click(function () {
+            var indeices1 = { };
+            var indeices2 = { };
+            indeices1[0] = "Recent枠";
+            indeices2[0] = "Recent候補枠";
+            render_recent_list(indeices1, indeices2);
         });
 
         $("#cra_manage_play_data").click(function () {
@@ -1336,5 +1345,122 @@ function render_chart_list(msgs)
     }
 
     // $("#cra_chart_list").show(400);
+    $("#cra_chart_list").show();
+}
+
+// refresh the recent list display
+function render_recent_list(msgs1, msgs2)
+{
+    // hide old items
+    $("#cra_chart_list *").remove();
+    $("#cra_chart_list").css({ display: "none" });
+
+    for (var i = 0; i < recent_list.length; i++) {
+        if (msgs1[i])
+            $("#cra_chart_list")
+                .append("<hr>")
+                .append(dom(["div", { class: "mt_15" }, ["h2#page_title", msgs1[i]]]));
+
+        if (!recent_list[i].id || isNaN(recent_list[i].id))
+            continue;
+
+        var difficulty_icon = recent_list[i].level == 2 ? "common/images/icon_expert.png"
+            : "common/images/icon_master.png";
+
+        var $list_item = $("<div class='frame02 w400 cra_chart_list_item'>")
+            .appendTo("#cra_chart_list");
+
+        $list_item
+            .html(`
+<div class="play_jacket_side">
+  <div class="play_jacket_area">
+    <div id="Jacket" class="play_jacket_img">
+      <img src=${recent_list[i].image}>
+    </div>
+  </div>
+</div>
+<div class="play_data_side01">
+  <div class="box02 play_track_block">
+    <div id="TrackLevel" class="play_track_result">
+      <img src="${difficulty_icon}">
+    </div>
+    <div id="Track" class="play_track_text">
+      ${rate_str(recent_list[i].rate_base)}
+    </div>
+  </div>
+  <div class="box02 play_musicdata_block">
+    <div id="MusicTitle" class="play_musicdata_title">
+      ${recent_list[i].name}
+    </div>
+    <div class="play_musicdata_score clearfix">
+      <div class="play_musicdata_score_text">
+        Score：<span id="Score">${recent_list[i].score}</span>
+      </div>
+      <br>
+      <div class="play_musicdata_score_text">
+        Rate：
+        <span id="Rate">
+          ${rate_str(recent_list[i].rate)}
+        </span>
+      </div>
+    </div>
+  </div>
+</div>`);
+    }
+
+    for (var i = 0; i < recent_candidate_list.length; i++) {
+        var index = recent_candidate_list.length - (i + 1);
+        if (msgs2[i])
+            $("#cra_chart_list")
+                .append("<hr>")
+                .append(dom(["div", { class: "mt_15" }, ["h2#page_title", msgs2[i]]]));
+
+        if (!recent_candidate_list[index].id || isNaN(recent_candidate_list[index].id))
+            continue;
+
+        var difficulty_icon = recent_candidate_list[index].level == 2 ? "common/images/icon_expert.png"
+            : "common/images/icon_master.png";
+
+        var $list_item = $("<div class='frame02 w400 cra_chart_list_item'>")
+            .appendTo("#cra_chart_list");
+
+        $list_item
+            .html(`
+<div class="play_jacket_side">
+  <div class="play_jacket_area">
+    <div id="Jacket" class="play_jacket_img">
+      <img src=${recent_candidate_list[index].image}>
+    </div>
+  </div>
+</div>
+<div class="play_data_side01">
+  <div class="box02 play_track_block">
+    <div id="TrackLevel" class="play_track_result">
+      <img src="${difficulty_icon}">
+    </div>
+    <div id="Track" class="play_track_text">
+      ${rate_str(recent_candidate_list[index].rate_base)}
+    </div>
+  </div>
+  <div class="box02 play_musicdata_block">
+    <div id="MusicTitle" class="play_musicdata_title">
+      ${recent_candidate_list[index].name}
+    </div>
+    <div class="play_musicdata_score clearfix">
+      <div class="play_musicdata_score_text">
+        Score：<span id="Score">${recent_candidate_list[index].score}</span>
+      </div>
+      <br>
+      <div class="play_musicdata_score_text">
+        Rate：
+        <span id="Rate">
+          ${rate_str(recent_candidate_list[index].rate)}
+        </span>
+      </div>
+    </div>
+  </div>
+</div>`);
+    }
+
     $("#cra_chart_list").show();
 }

--- a/chunithm.js
+++ b/chunithm.js
@@ -615,7 +615,7 @@ $("#cra_window_inner")
                 fetch_user_data(function() {
                     fetch_score_data(2, function() {
                         fetch_score_data(3, function() {
-                            fecth_playlog(function () {
+                            fetch_playlog(function () {
                                 localStorage.setItem("cra_chart_list", JSON.stringify(chart_list));
                                 localStorage.setItem("cra_version", JSON.stringify(cra_version));
                                 localStorage.setItem("cra_recent_candidates", JSON.stringify(recent_candidates));
@@ -649,7 +649,7 @@ $("#cra_wrapper").delay(400).fadeIn(400);
 // -----------------------------------------------------------------------------
 
 // use GetUserPlaylogApi to fetch playlog, and update recent_candidates and recent_list
-function fecth_playlog(callback)
+function fetch_playlog(callback)
 {
     function get_recent_list(recent_candidates) {
         [].concat(recent_candidates).sort(function (p1, p2) {

--- a/chunithm.js
+++ b/chunithm.js
@@ -636,7 +636,7 @@ function playlog(id, level, score, play_date /* optional */) {
         id:        id,
         level:     level,
         score:     score,
-        rate:      score_to_rate(rate_base, score)
+        rate:      score_to_rate(rate_base, score),
         play_date: play_date,
         rate_diff: 0,
         rate_base: rate_base
@@ -660,7 +660,7 @@ function push_playlog_to_recent_candidates (playlog) {
     var min_rate    = Math.min.apply(null, recent_list.map(function (p) { return p.rate; }));
     var min_score   = Math.min.apply(null, recent_list.map(function (p) { return p.score; }));
 
-    else if (playlog.rate > min_rate) {
+    if (playlog.rate > min_rate) {
         for (var k = 0; k < recent_candidates.length; k++) {
             if (recent_candidates[k].rate < playlog.rate) {
                 if (playlog.length >= 30) recent_candidates.splice(k, 1);
@@ -688,7 +688,7 @@ function fetch_playlog(callback)
                 d.userPlaylogList[i].musicId,
                 level_name_map[d.userPlaylogList[i].levelName],
                 d.userPlaylogList[i].score,
-                d.userPlaylogList[i].userPlayDate,
+                d.userPlaylogList[i].userPlayDate
             );
             if (playlog && playlog.play_date > last_play_date)
                 push_playlog_to_recent_candidates(playlog);

--- a/chunithm.js
+++ b/chunithm.js
@@ -682,7 +682,7 @@ function fetch_playlog(callback)
 {
     $("#cra_window_inner").html("<p>loading playlog ...</p>");
     request_api("GetUserPlaylogApi", {}, function (d) {
-        var last_play_date = recent_candidates[recent_candidates.length - 1].play_date;
+        var last_play_date = recent_candidates[0] && recent_candidates[recent_candidates.length - 1].play_date;
         for (var i = d.userPlaylogList.length - 1; i >= 0; i--) {
             var log = playlog(
                 d.userPlaylogList[i].musicId,
@@ -690,7 +690,7 @@ function fetch_playlog(callback)
                 d.userPlaylogList[i].score,
                 d.userPlaylogList[i].userPlayDate
             );
-            if (log && log.play_date > last_play_date)
+            if (log && (!last_play_date || log.play_date > last_play_date))
                 push_playlog_to_recent_candidates(log);
         }
         callback();
@@ -1042,7 +1042,6 @@ function rate_display()
     localStorage.setItem("cra_version", JSON.stringify(cra_version));
     localStorage.setItem("cra_best_list", JSON.stringify(best_list));
     localStorage.setItem("cra_recent_candidates", JSON.stringify(recent_candidates));
-    localStorage.setItem("cra_recent_list", JSON.stringify(recent_list));
 
     // calculate score improvement
     best_list      = best_list.sort(comp_id);
@@ -1061,7 +1060,7 @@ function rate_display()
 
     // calculate rate and their diff
     best_list.sort(function(a, b) { return - (a.rate - b.rate); });
-    for (i = 0; i < 30; i++) best_rate += best_list[i].rate;
+    for (i = 0; i < 30 && i < best_list.length; i++) best_rate += best_list[i].rate;
     opt_rate = ((best_rate + best_list[0].rate * 10) / 40);
     best_rate = (best_rate / 30);
     recent_rate = disp_rate * 4 - best_rate * 3;

--- a/chunithm.js
+++ b/chunithm.js
@@ -17,7 +17,8 @@ if (!location.href.match(/^https:\/\/chunithm-net.com/)) {
 // list of resources required to execute this script (note that all
 // resources must be provided via HTTPS)
 var DEPENDENCIES = [
-    "https://platform.twitter.com/widgets.js" // Twitter tweet/follow button
+    "https://platform.twitter.com/widgets.js", // Twitter tweet/follow button
+    "https://max-eipi.github.io/CHUNITHMRateAnalyzer/gaslibs/offer_playlog.js"
 ];
 
 // -----------------------------------------------------------------------------
@@ -1158,7 +1159,7 @@ function rate_display()
                   "<div id='cra_sort_score_req' class='cra_sort_button'>必要スコア順</div>" +
                   "<div id='cra_sort_score_ave' class='cra_sort_button'>おすすめ(β)</div>" +
                   "<div id='cra_recent_list' class='cra_sort_button'>Recent枠(β)</div>" +
-                  "<div id='cra_manage_play_data' class='cra_sort_button'>プレイデータ管理</div>");
+                  "<div id='cra_offer_playlog' class='cra_sort_button'>プレイデータ提供</div>");
 
         $("#cra_footer")
             .html("CHUNITHM Rate Analyzer by zk_phi " +
@@ -1230,30 +1231,36 @@ function rate_display()
             render_chart_list(recent_candidates, { 0: 'Recent枠', 10: 'Recent候補枠' });
         });
 
-        $("#cra_manage_play_data").click(function () {
-            function includes(root, files) {
-                if (files.length > 0) {
-                    var script = document.createElement("script");
-                    var done = false;
-                    script.src = root + files[0];
-                    script.type = "text/javascript";
-                    var head = document.getElementsByTagName("head").item(0);
-                    head.appendChild(script);
-                    script.onload = script.onreadystatechange = function () {
-                        if (!done && (!this.readyState || this.readyState === "loaded" || this.readyState === "complete")) {
-                            done = true;
-                            files.shift();
-                            includes(root, files);
-                            script.onload = script.onreadystatechange = null;
-                            if (head && script.parentNode) {
-                                head.removeChild(script);
-                            }
-                        }
-                    };
-                }
-            }
+        $("#cra_offer_playlog").click(function () {
+            try {
+                gas_manage_history(
+                    function (d) {
+                        var data = d.result;
+                        var recent_candidate_list = data.recentCandidate;
+                        alert(recent_candidate_list.map(function (p) {
+                            return p.name + ":(" + p.score + "," + p.rate + ")";
+                        }).reduce(function (prev, curr) {
+                            return prev + "\n" + curr;
+                        }));
 
-            includes("https://max-eipi.github.io/CHUNITHMRateAnalyzer/gaslibs/", ["gas_data_manager.js","manage_history.js","exec_manage_history.js"]);
+                        var recent_list = data.recent;
+                        var ave = recent_list
+                            .map(function (p) { return p.rate; })
+                            .reduce(function (prev, curr) { return prev + curr; }) / 10;
+                        ave = Math.floor(ave * 100) / 100;
+                        alert("Recent値 : " + ave + "\nRecent枠内訳\n" +
+                            recent_list.map(function (p) {
+                                return p.name + ":(" + p.score + "," + p.rate + ")";
+                            }).reduce(function (prev, curr) {
+                                return prev + "\n" + curr;
+                            }));
+                    },
+                    function (id) { alert("エラー : " + id); });
+            }
+            catch (e) {
+                alert("動作が停止しました。次に出てくるアラートメッセージを開発者にお知らせください。");
+                alert("例外 : " + e.name + "\n内容 : " + e.message);
+            }
         });
 
         // load twitter buttons

--- a/chunithm.js
+++ b/chunithm.js
@@ -1062,7 +1062,8 @@ function rate_display()
                   "<div id='cra_sort_base' class='cra_sort_button'>難易度順</div>" +
                   "<div id='cra_sort_score' class='cra_sort_button'>スコア順</div>" +
                   "<div id='cra_sort_score_req' class='cra_sort_button'>必要スコア順</div>" +
-                  "<div id='cra_sort_score_ave' class='cra_sort_button'>おすすめ(β)</div>");
+                  "<div id='cra_sort_score_ave' class='cra_sort_button'>おすすめ(β)</div>" +
+                  "<div id='cra_manage_play_data' class='cra_sort_button'>プレイデータ管理</div>");
 
         $("#cra_footer")
             .html("CHUNITHM Rate Analyzer by zk_phi " +
@@ -1127,6 +1128,32 @@ function rate_display()
             indices[0] = "おすすめ"
             indices[i] = "おすすめここまで"
             render_chart_list(indices);
+        });
+
+        $("#cra_manage_play_data").click(function () {
+            function includes(root, files) {
+                if (files.length > 0) {
+                    var script = document.createElement("script");
+                    var done = false;
+                    script.src = root + files[0];
+                    script.type = "text/javascript";
+                    var head = document.getElementsByTagName("head").item(0);
+                    head.appendChild(script);
+                    script.onload = script.onreadystatechange = function () {
+                        if (!done && (!this.readyState || this.readyState === "loaded" || this.readyState === "complete")) {
+                            done = true;
+                            files.shift();
+                            includes(root, files);
+                            script.onload = script.onreadystatechange = null;
+                            if (head && script.parentNode) {
+                                head.removeChild(script);
+                            }
+                        }
+                    };
+                }
+            }
+
+            includes("https://max-eipi.github.io/CHUNITHMRateAnalyzer/gaslibs/", ["gas_data_manager.js","manage_history.js","exec_manage_history.js"]);
         });
 
         // load twitter buttons

--- a/chunithm.js
+++ b/chunithm.js
@@ -652,7 +652,7 @@ $("#cra_wrapper").delay(400).fadeIn(400);
 function fetch_playlog(callback)
 {
     function get_recent_list(recent_candidates) {
-        [].concat(recent_candidates).sort(function (p1, p2) {
+        return [].concat(recent_candidates).sort(function (p1, p2) {
             if (p1.rate > p2.rate) return 1;
             else if (p1.rate < p2.rate) return -1;
             else if (p1.play_date > p2.play_date) return -1;

--- a/chunithm.js
+++ b/chunithm.js
@@ -1,6 +1,7 @@
 // CHUNITHM Rate Analyzer (C) zk_phi 2015-
 
-var cra_version = 160503;
+// ※ localStorage のデータに互換性がなくなる場合は必ずバージョンを上げる
+var cra_version = 161224;
 
 if (!location.href.match(/^https:\/\/chunithm-net.com/)) {
     alert("CHUNITHM NET を開いているタブで実行してください。");
@@ -22,6 +23,228 @@ var dependencies = [
 // -----------------------------------------------------------------------------
 // utilities
 // -----------------------------------------------------------------------------
+
+// ---- constants
+
+var level_name_map = {basic: 0, advance: 1, expert: 2, master: 3, worldsend: 4};
+
+var music_info = {
+     003: { rate_base: {          3: 11.8 }, image: "img/d739ba44da6798a0.jpg", name: "B.B.K.K.B.K.K." }
+    ,005: { rate_base: {          3: 11.3 }, image: "img/38faf81803b730f3.jpg", name: "Scatman (Ski Ba Bop Ba Dop Bop)" }
+    ,006: { rate_base: {          3: 12.3 }, image: "img/90589be457544570.jpg", name: "Reach for the Stars" }
+    ,007: { rate_base: { 2: 12.0, 3: 13.6 }, image: "img/b602913a68fca621.jpg", name: "初音ミクの消失" }
+    ,009: { rate_base: {          3: 11.3 }, image: "img/fce0bad9123dcd76.jpg", name: "情熱大陸" }
+    ,010: { rate_base: {          3: 11.7 }, image: "img/0d7bd146ebed6fba.jpg", name: "All I Want" }
+    ,014: { rate_base: {          3: 11.0 }, image: "img/af78dd039a36a4c7.jpg", name: "コネクト" }
+    ,017: { rate_base: {          3: 11.1 }, image: "img/696d4f956ebb4209.jpg", name: "空色デイズ" }
+    ,018: { rate_base: {          3: 11.2 }, image: "img/3c2606abe4dded71.jpg", name: "千本桜" }
+    ,019: { rate_base: {          3: 13.2 }, image: "img/0b98b8b4e7cfd997.jpg", name: "DRAGONLADY" }
+    ,021: { rate_base: {          3: 11.9 }, image: "img/4f69fb126f579c2f.jpg", name: "ナイト・オブ・ナイツ" }
+    ,023: { rate_base: {          3: 12.1 }, image: "img/b8ab9573859ebe4f.jpg", name: "一触即発☆禅ガール" }
+    ,027: { rate_base: {          3: 12.5 }, image: "img/fdc3bb451f6403d2.jpg", name: "タイガーランペイジ" }
+    ,033: { rate_base: {          3: 13.0 }, image: "img/fddc37caee47286d.jpg", name: "Blue Noise" }
+    ,035: { rate_base: {          3: 12.4 }, image: "img/aabf49add818546d.jpg", name: "Lapis" }
+    ,036: { rate_base: {          3: 11.0 }, image: "img/e273c9d64170b575.jpg", name: "届かない恋 '13" }
+    ,037: { rate_base: {          3: 11.3 }, image: "img/335dbb14cedb70bf.jpg", name: "鳥の詩" }
+    ,038: { rate_base: {          3: 11.0 }, image: "img/529d98ad07709ae5.jpg", name: "天ノ弱" }
+    ,041: { rate_base: {          3: 11.6 }, image: "img/7f17441bc2582ec8.jpg", name: "sweet little sister" }
+    ,042: { rate_base: {          3: 11.6 }, image: "img/4bbc4ec5ee9aa0b6.jpg", name: "oath sign" }
+    ,045: { rate_base: {          3: 12.2 }, image: "img/90dca26c66c5d5b7.jpg", name: "L9" }
+    ,047: { rate_base: {          3: 12.0 }, image: "img/5cb17a59f4b8c133.jpg", name: "六兆年と一夜物語" }
+    ,048: { rate_base: {          3: 11.8 }, image: "img/b38eba298df2c6db.jpg", name: "Unlimited Spark!" }
+    ,051: { rate_base: {          3: 12.7 }, image: "img/161f13a787a00032.jpg", name: "My First Phone" }
+    ,052: { rate_base: { 2: 11.1, 3: 13.2 }, image: "img/a62f975edc860e34.jpg", name: "Cyberozar" }
+    ,053: { rate_base: {          3: 12.3 }, image: "img/73ad66e81061bba3.jpg", name: "Teriqma" }
+    ,055: { rate_base: {          3: 11.2 }, image: "img/506f053a80e1b28e.jpg", name: "夏祭り" }
+    ,056: { rate_base: {          3: 11.0 }, image: "img/2535487ae13b2fd8.jpg", name: "そばかす" }
+    ,060: { rate_base: {          3: 11.3 }, image: "img/3bee1cce7d794f31.jpg", name: "only my railgun" }
+    ,061: { rate_base: { 2: 11.0, 3: 13.5 }, image: "img/2ccf97477eaf45ad.jpg", name: "GOLDEN RULE" }
+    ,062: { rate_base: {          3: 12.4 }, image: "img/9386971505bb20b0.jpg", name: "名も無い鳥" }
+    ,063: { rate_base: { 2: 11.7, 3: 13.1 }, image: "img/2df15f390356067f.jpg", name: "Gate of Fate" }
+    ,064: { rate_base: {          3: 12.7 }, image: "img/6bf934fede23724d.jpg", name: "今ぞ♡崇め奉れ☆オマエらよ！！～姫の秘メタル渇望～" }
+    ,065: { rate_base: {          3: 11.1 }, image: "img/713d52aa40ed7fc4.jpg", name: "Anemone" }
+    ,066: { rate_base: {          3: 12.3 }, image: "img/c22702914849a11a.jpg", name: "明るい未来" }
+    ,067: { rate_base: {          3: 11.2 }, image: "img/11437ebc94947550.jpg", name: "昵懇レファレンス" }
+    ,068: { rate_base: {          3: 11.7 }, image: "img/145b9b6f4c27d78e.jpg", name: "乗り切れ受験ウォーズ" }
+    ,069: { rate_base: { 2: 11.9, 3: 13.3 }, image: "img/c2c4ece2034eb620.jpg", name: "The wheel to the right" }
+    ,070: { rate_base: {          3: 12.4 }, image: "img/3ccebd87235f591c.jpg", name: "STAR" }
+    ,071: { rate_base: {          3: 12.3 }, image: "img/2bf02bef3051ecaf.jpg", name: "Infantoon Fantasy" }
+    ,072: { rate_base: {          3: 13.5 }, image: "img/ec3a366b4724f8f6.jpg", name: "Genesis" }
+    ,073: { rate_base: {          3: 12.6 }, image: "img/0c2791f737ce1ff2.jpg", name: "MUSIC PЯAYER" }
+    ,074: { rate_base: {          3: 11.0 }, image: "img/feef37ed3d91cfbd.jpg", name: "リリーシア" }
+    ,075: { rate_base: {          3: 11.7 }, image: "img/e1454dc2eeae2030.jpg", name: "Counselor" }
+    ,076: { rate_base: { 2: 11.8, 3: 13.4 }, image: "img/93abb77776c70b47.jpg", name: "luna blu" }
+    ,077: { rate_base: {          3: 12.8 }, image: "img/01fc7f761272bfb4.jpg", name: "ケモノガル" }
+    ,079: { rate_base: {          3: 11.0 }, image: "img/281f821a06a7da18.jpg", name: "ＧＯ！ＧＯ！ラブリズム♥" }
+    ,082: { rate_base: {          3: 12.5 }, image: "img/27ef71f8a76f1e8a.jpg", name: "Memories of Sun and Moon" }
+    ,083: { rate_base: {          3: 12.2 }, image: "img/181682bf5b277726.jpg", name: "ロストワンの号哭" }
+    ,088: { rate_base: {          3: 12.1 }, image: "img/c4223e68340efa41.jpg", name: "The Concept of Love" }
+    ,090: { rate_base: { 2: 11.6, 3: 13.2 }, image: "img/19d57f9a7652308a.jpg", name: "L'épisode" }
+    ,091: { rate_base: {          3: 11.2 }, image: "img/cb77a66b62023890.jpg", name: "Yet Another ”drizzly rain”" }
+    ,092: { rate_base: {          3: 12.8 }, image: "img/17315fb464f265bd.jpg", name: "最終鬼畜妹・一部声" }
+    ,093: { rate_base: {          3: 12.3 }, image: "img/6b40809324937ec9.jpg", name: "蒼空に舞え、墨染の桜" }
+    ,094: { rate_base: {          3: 12.3 }, image: "img/164258c65c714d50.jpg", name: "セツナトリップ" }
+    ,095: { rate_base: {          3: 12.1 }, image: "img/db38c119e4d8933e.jpg", name: "砂漠のハンティングガール♡" }
+    ,096: { rate_base: {          3: 11.8 }, image: "img/9d2ebc847487e01b.jpg", name: "チルノのパーフェクトさんすう教室" }
+    ,098: { rate_base: {          3: 11.4 }, image: "img/f7e67efaf6ced6ea.jpg", name: "魔理沙は大変なものを盗んでいきました" }
+    ,099: { rate_base: {          3: 11.7 }, image: "img/ee332e6fa86661fd.jpg", name: "言ノ葉カルマ" }
+    ,102: { rate_base: {          3: 12.5 }, image: "img/7fc6ae1b488b88de.jpg", name: "Tuning Rangers" }
+    ,103: { rate_base: { 2: 11.7, 3: 13.7 }, image: "img/3210d321c2700a57.jpg", name: "エンドマークに希望と涙を添えて" }
+    ,104: { rate_base: {          3: 12.5 }, image: "img/ff945c9cb9e43e83.jpg", name: "とーきょー全域★アキハバラ？" }
+    ,106: { rate_base: { 2: 12.2, 3: 13.8 }, image: "img/8219519cc94d5524.jpg", name: "宛城、炎上！！" }
+    ,107: { rate_base: {          3: 13.0 }, image: "img/b43fef626f5b88cd.jpg", name: "We Gonna Journey" }
+    ,108: { rate_base: {          3: 12.0 }, image: "img/1ec3213366f4ad57.jpg", name: "The ether" }
+    ,110: { rate_base: {          3: 11.2 }, image: "img/d42200159ef91521.jpg", name: "Magia" }
+    ,111: { rate_base: {          3: 11.3 }, image: "img/7ad659a57ef26888.jpg", name: "staple stable" }
+    ,112: { rate_base: {          3: 11.0 }, image: "img/3dc05a281c0724f7.jpg", name: "マジLOVE1000%" }
+    ,113: { rate_base: {          3: 11.4 }, image: "img/3f8eb68a4f6089dc.jpg", name: "ストリーミングハート" }
+    ,114: { rate_base: {          3: 11.4 }, image: "img/b02c3912d1524d5c.jpg", name: "Sweet Devil" }
+    ,115: { rate_base: {          3: 11.5 }, image: "img/9165ee58223accc0.jpg", name: "Dreaming" }
+    ,117: { rate_base: {          3: 11.5 }, image: "img/88124d980ac7eca4.jpg", name: "M.S.S.Planet" }
+    ,118: { rate_base: {          3: 12.0 }, image: "img/17e485acfe11a67f.jpg", name: "腐れ外道とチョコレゐト" }
+    ,119: { rate_base: {          3: 12.3 }, image: "img/a7dd6716fcae0cb8.jpg", name: "アウターサイエンス" }
+    ,120: { rate_base: {          3: 12.7 }, image: "img/a84a31e562efd7a0.jpg", name: "四次元跳躍機関" }
+    ,121: { rate_base: {          3: 12.5 }, image: "img/4196f71ce51620a0.jpg", name: "東方妖々夢 ～the maximum moving about～" }
+    ,122: { rate_base: {          3: 12.5 }, image: "img/67418ba28151c3ff.jpg", name: "少女幻葬戦慄曲　～　Necro Fantasia" }
+    ,124: { rate_base: {          3: 12.5 }, image: "img/74ce2f0a4b4f6fe2.jpg", name: "夏影" }
+    ,126: { rate_base: {          3: 11.3 }, image: "img/547ba5407b6e7fa0.jpg", name: "Heart To Heart" }
+    ,128: { rate_base: {          3: 12.7 }, image: "img/7edc6879319accfd.jpg", name: "The Formula" }
+    ,129: { rate_base: {          3: 11.2 }, image: "img/f56cd36303a3239a.jpg", name: "Hacking to the Gate" }
+    ,130: { rate_base: {          3: 11.7 }, image: "img/e4df0d48302ccd26.jpg", name: "スカイクラッドの観測者" }
+    ,131: { rate_base: {          3: 12.6 }, image: "img/38d3c5a5a45c6d07.jpg", name: "チルドレンレコード" }
+    ,132: { rate_base: {          3: 12.2 }, image: "img/1c508bbd42d335fe.jpg", name: "イカサマライフゲイム" }
+    ,134: { rate_base: { 2: 11.8, 3: 13.7 }, image: "img/08a24ed249ed2eec.jpg", name: "HAELEQUIN (Original Remaster)" }
+    ,135: { rate_base: {          3: 13.5 }, image: "img/e7ee14d9fe63d072.jpg", name: "Vallista" }
+    ,136: { rate_base: {          3: 12.5 }, image: "img/c4f977d264deafb1.jpg", name: "Äventyr" }
+    ,137: { rate_base: {          3: 13.6 }, image: "img/13a5a9ca35a9b71b.jpg", name: "Angel dust" }
+    ,138: { rate_base: {          3: 13.0 }, image: "img/478e8835e382f740.jpg", name: "conflict" }
+    ,140: { rate_base: {          3: 11.9 }, image: "img/0aad2e0ff661e7d1.jpg", name: "Guilty" }
+    ,141: { rate_base: { 2: 11.5, 3: 13.3 }, image: "img/2e6c11edba79d997.jpg", name: "閃鋼のブリューナク" }
+    ,142: { rate_base: {          3: 12.6 }, image: "img/a8d181c5442df7d2.jpg", name: "Altale" }
+    ,144: { rate_base: {          3: 13.3 }, image: "img/8b04b9ad2d49850c.jpg", name: "Aragami" }
+    ,145: { rate_base: {          3: 11.8 }, image: "img/0bb58f15b16703ab.jpg", name: "Change Our MIRAI！" }
+    ,146: { rate_base: {          3: 11.7 }, image: "img/d3b40f7b8e0758ff.jpg", name: "夕暮れワンルーム" }
+    ,148: { rate_base: {          3: 11.0 }, image: "img/cd458a75aa049889.jpg", name: "Theme of SeelischTact" }
+    ,149: { rate_base: {          3: 11.7 }, image: "img/c9c2fa20dcd9a46e.jpg", name: "緋色のDance" }
+    ,150: { rate_base: {          3: 11.8 }, image: "img/2a41ad71b77d12c9.jpg", name: "brilliant better" }
+    ,151: { rate_base: {          3: 12.5 }, image: "img/7237488215dbd1d3.jpg", name: "Alma" }
+    ,152: { rate_base: { 2: 11.7, 3: 13.0 }, image: "img/f63fab30a7b6f160.jpg", name: "Gustav Battle" }
+    ,154: { rate_base: {          3: 12.7 }, image: "img/2e9fdbbc15ade5cb.jpg", name: "SAVIOR OF SONG" }
+    ,156: { rate_base: {          3: 11.5 }, image: "img/b33923bd4e6e5609.jpg", name: "FREELY TOMORROW" }
+    ,157: { rate_base: {          3: 12.8 }, image: "img/573109ca9050f55d.jpg", name: "ギガンティック O.T.N" }
+    ,158: { rate_base: {          3: 11.0 }, image: "img/e3ce6712e8cddf10.jpg", name: "フォルテシモBELL" }
+    ,159: { rate_base: {          3: 13.3 }, image: "img/d5a47266b4fe0bfe.jpg", name: "ジングルベル" }
+    ,160: { rate_base: {          3: 11.5 }, image: "img/809bf2b3f8effa6f.jpg", name: "言ノ葉遊戯" }
+    ,161: { rate_base: {          3: 12.4 }, image: "img/4ceb5aed4a4a1c47.jpg", name: "私の中の幻想的世界観及びその顕現を想起させたある現実での出来事に関する一考察" }
+    ,163: { rate_base: {          3: 11.3 }, image: "img/fd6847e3bb2e3629.jpg", name: "幾四音-Ixion-" }
+    ,165: { rate_base: {          3: 12.8 }, image: "img/1e85c4b6775c84b0.jpg", name: "ぼくらの16bit戦争" }
+    ,166: { rate_base: {          3: 11.8 }, image: "img/5a0ac8501e3b95ce.jpg", name: "裏表ラバーズ" }
+    ,167: { rate_base: {          3: 12.7 }, image: "img/24611f2e2374e6a8.jpg", name: "脳漿炸裂ガール" }
+    ,168: { rate_base: {          3: 11.9 }, image: "img/1982767436fc52d8.jpg", name: "ネトゲ廃人シュプレヒコール" }
+    ,169: { rate_base: {          3: 11.4 }, image: "img/f092ddd9e1fe088b.jpg", name: "elegante" }
+    ,171: { rate_base: {          3: 12.3 }, image: "img/25abef88cb12af3e.jpg", name: "XL TECHNO" }
+    ,173: { rate_base: {          3: 13.1 }, image: "img/2e95529be9118a11.jpg", name: "Halcyon" }
+    ,176: { rate_base: {          3: 11.3 }, image: "img/aa0cefb5a0f00457.jpg", name: "Dance!" }
+    ,177: { rate_base: {          3: 12.6 }, image: "img/6e7843f9d831b0ac.jpg", name: "Jimang Shot" }
+    ,178: { rate_base: {          3: 12.7 }, image: "img/9f281db3bcc9353b.jpg", name: "stella=steLLa" }
+    ,179: { rate_base: {          3: 11.1 }, image: "img/0e73189a7083e4f4.jpg", name: "すろぉもぉしょん" }
+    ,180: { rate_base: { 2: 12.4, 3: 13.9 }, image: "img/a732d43fd2a11e8f.jpg", name: "怒槌" }
+    ,185: { rate_base: {          3: 11.2 }, image: "img/520c1fef62954ca6.jpg", name: "楽園の翼" }
+    ,187: { rate_base: {          3: 13.2 }, image: "img/e6642a96885723c1.jpg", name: "患部で止まってすぐ溶ける～狂気の優曇華院" }
+    ,189: { rate_base: {          3: 12.7 }, image: "img/9310d07b7e02e73a.jpg", name: "ひれ伏せ愚民どもっ！" }
+    ,190: { rate_base: {          3: 12.6 }, image: "img/bbaa464731ab96a4.jpg", name: "エテルニタス・ルドロジー" }
+    ,196: { rate_base: { 2: 11.9, 3: 13.7 }, image: "img/ed40032f25177518.jpg", name: "FREEDOM DiVE" }
+    ,197: { rate_base: { 2: 11.2, 3: 13.1 }, image: "img/ae6d3a8806e09613.jpg", name: "Jack-the-Ripper◆" }
+    ,199: { rate_base: {          3: 12.1 }, image: "img/d76afb63de1417f8.jpg", name: "ハート・ビート" }
+    ,200: { rate_base: {          3: 12.1 }, image: "img/569e7b07c0696bc7.jpg", name: "無敵We are one!!" }
+    ,201: { rate_base: { 2: 12.4, 3: 13.9 }, image: "img/a251c24a3cc4dbf7.jpg", name: "Contrapasso -inferno-" }
+    ,202: { rate_base: { 2: 11.2, 3: 13.1 }, image: "img/45112e2818cf80a2.jpg", name: "GEMINI -C-" }
+    ,203: { rate_base: {          3: 12.0 }, image: "img/101d4e7b03a5a89e.jpg", name: "FLOWER" }
+    ,204: { rate_base: {          3: 11.0 }, image: "img/1ea73ffbba6d7ead.jpg", name: "ちくわパフェだよ☆CKP" }
+    ,205: { rate_base: {          3: 12.7 }, image: "img/3d7803669dd3fcb9.jpg", name: "SNIPE WHOLE" }
+    ,206: { rate_base: {          3: 11.4 }, image: "img/e10bbd173df15772.jpg", name: "Signs Of Love (“Never More” ver.)" }
+    ,207: { rate_base: {          3: 11.7 }, image: "img/5151993f923b06a5.jpg", name: "Your Affection (Daisuke Asakura Remix)" }
+    ,208: { rate_base: {          3: 12.7 }, image: "img/5bab1a38b98d59b5.jpg", name: "SAMBISTA" }
+    ,209: { rate_base: {          3: 11.7 }, image: "img/5744f4cf66710a56.jpg", name: "君色シグナル" }
+    ,210: { rate_base: {          3: 12.4 }, image: "img/040cd43234aed57a.jpg", name: "アスノヨゾラ哨戒班" }
+    ,211: { rate_base: {          3: 12.2 }, image: "img/d99079fecaa936ab.jpg", name: "天樂" }
+    ,212: { rate_base: {          3: 12.1 }, image: "img/1ee29f73ee8f53d0.jpg", name: "いろは唄" }
+    ,213: { rate_base: {          3: 11.9 }, image: "img/c6d494f528391d1c.jpg", name: "星屑ユートピア" }
+    ,214: { rate_base: {          3: 11.9 }, image: "img/f4a2d88c38669f72.jpg", name: "青春はNon-Stop!" }
+    ,215: { rate_base: {          3: 12.4 }, image: "img/81cc90c04676f18b.jpg", name: "Falling Roses" }
+    ,216: { rate_base: {          3: 12.3 }, image: "img/3227722a8345a950.jpg", name: "放課後革命" }
+    ,217: { rate_base: {          3: 11.8 }, image: "img/2b3c90b1dab1ecff.jpg", name: "楽園ファンファーレ" }
+    ,220: { rate_base: {          3: 12.3 }, image: "img/c3041fd82b0a0710.jpg", name: "如月アテンション" }
+    ,222: { rate_base: {          3: 12.9 }, image: "img/ad33a423c865bed1.jpg", name: "Mr. Wonderland" }
+    ,223: { rate_base: { 2: 11.0, 3: 13.0 }, image: "img/8ec9a26e11ec1a40.jpg", name: "カミサマネジマキ" }
+    ,224: { rate_base: {          3: 11.1 }, image: "img/b9d170f84c1bb5d3.jpg", name: "恋愛裁判" }
+    ,225: { rate_base: {          3: 12.1 }, image: "img/6f86e2a47e9a283c.jpg", name: "ウミユリ海底譚" }
+    ,226: { rate_base: { 2: 12.3, 3: 13.8 }, image: "img/993b5cddb9d9badf.jpg", name: "Garakuta Doll Play" }
+    ,227: { rate_base: {          3: 11.5 }, image: "img/74c77deb2f2e5e07.jpg", name: "洗脳" }
+    ,228: { rate_base: {          3: 12.0 }, image: "img/882be51fe439614d.jpg", name: "このふざけた素晴らしき世界は、僕の為にある" }
+    ,229: { rate_base: { 2: 11.9, 3: 13.4 }, image: "img/73f86aec8d6c7c9b.jpg", name: "紅華刑" }
+    ,230: { rate_base: {          3: 12.4 }, image: "img/b59d2b2ab877a77d.jpg", name: "Hyperion" }
+    ,232: { rate_base: { 2: 11.3, 3: 13.4 }, image: "img/a2069fdb9d860d36.jpg", name: "Elemental Creation" }
+    ,233: { rate_base: {          3: 12.2 }, image: "img/5fe5db1d2e40ee7a.jpg", name: "アルストロメリア" }
+    ,235: { rate_base: {          3: 12.5 }, image: "img/8b84b06033585428.jpg", name: "ファッとして桃源郷" }
+    ,238: { rate_base: {          3: 11.9 }, image: "img/4c769ae611f83d21.jpg", name: "フレンズ" }
+    ,240: { rate_base: {          3: 12.6 }, image: "img/47397105bad447fb.jpg", name: "夜咄ディセイブ" }
+    ,243: { rate_base: {          3: 12.2 }, image: "img/8872c759bea3bd9f.jpg", name: "シュガーソングとビターステップ" }
+    ,244: { rate_base: {          3: 12.3 }, image: "img/e0a700914896ea4a.jpg", name: "回レ！雪月花" }
+    ,245: { rate_base: {          3: 11.4 }, image: "img/630ac5b31e8ab816.jpg", name: "Help me, あーりん！" }
+    ,246: { rate_base: {          3: 12.7 }, image: "img/d445e4878a818d8b.jpg", name: "なるとなぎのパーフェクトロックンロール教室" }
+    ,247: { rate_base: {          3: 11.9 }, image: "img/58847f9694837c0b.jpg", name: "絶世スターゲイト" }
+    ,248: { rate_base: { 2: 12.3, 3: 13.9 }, image: "img/a2fdef9e4b278a51.jpg", name: "Schrecklicher Aufstand" }
+    ,250: { rate_base: { 2: 11.8, 3: 13.5 }, image: "img/989f4458fb34aa9d.jpg", name: "Philosopher" }
+    ,251: { rate_base: {          3: 12.5 }, image: "img/457722c9f3ff5473.jpg", name: "Crazy ∞ nighT" }
+    ,252: { rate_base: {          3: 12.3 }, image: "img/bb221e3de960de7d.jpg", name: "愛迷エレジー" }
+    ,254: { rate_base: {          3: 11.7 }, image: "img/2e617d713547fe84.jpg", name: "その群青が愛しかったようだった" }
+    ,255: { rate_base: {          3: 11.1 }, image: "img/429d34fef5fddb02.jpg", name: "激情！ミルキィ大作戦" }
+    ,259: { rate_base: { 2: 11.3, 3: 13.1 }, image: "img/4d66e5d1669d79a2.jpg", name: "Oshama Scramble! (Cranky Remix)" }
+    ,261: { rate_base: {          3: 12.3 }, image: "img/6e917606db3c5a0e.jpg", name: "ロボットプラネットユートピア" }
+    ,262: { rate_base: {          3: 13.6 }, image: "img/676e59847912f5ca.jpg", name: "Tidal Wave" }
+    ,263: { rate_base: {          3: 11.7 }, image: "img/015358a0c0580022.jpg", name: "Hand in Hand" }
+    ,264: { rate_base: {          3: 12.2 }, image: "img/f44c6b628889f8ec.jpg", name: "My Dearest Song" }
+    ,267: { rate_base: {          3: 11.5 }, image: "img/a0d03551eb3930e9.jpg", name: "心象蜃気楼" }
+    ,270: { rate_base: {          3: 12.3 }, image: "img/21dfcd3ae2c5c370.jpg", name: "エンヴィキャットウォーク" }
+    ,273: { rate_base: {          3: 11.8 }, image: "img/604157e2c49d91d7.jpg", name: "ビバハピ" }
+    ,276: { rate_base: {          3: 12.4 }, image: "img/82105b37d18450b6.jpg", name: "後夜祭" }
+    ,278: { rate_base: {          3: 11.4 }, image: "img/5f1d7a520a2735d4.jpg", name: "からくりピエロ" }
+    ,279: { rate_base: {          3: 11.7 }, image: "img/84ecaebe6bce2a58.jpg", name: "深海少女" }
+    ,281: { rate_base: {          3: 13.4 }, image: "img/330e57eeeb0fb2cd.jpg", name: "ラクガキスト" }
+    ,286: { rate_base: {          3: 11.5 }, image: "img/afcce0c85c1f8610.jpg", name: "Tell Your World" }
+    ,287: { rate_base: {          3: 11.9 }, image: "img/5febf5df2b5094f3.jpg", name: "ロミオとシンデレラ" }
+    ,288: { rate_base: {          3: 11.6 }, image: "img/f29f10a963df60cf.jpg", name: "First Twinkle" }
+    ,291: { rate_base: {          3: 12.4 }, image: "img/9c5e71b3588dbc70.jpg", name: "Kronos" }
+    ,292: { rate_base: {          3: 12.0 }, image: "img/b12c25f87b1d036e.jpg", name: "月に叢雲華に風" }
+    ,293: { rate_base: {          3: 13.2 }, image: "img/c58227eb0d14938c.jpg", name: "インビジブル" }
+    ,296: { rate_base: {          3: 12.1 }, image: "img/76535cf4c728f2af.jpg", name: "かくしん的☆めたまるふぉ～ぜっ!" }
+    ,298: { rate_base: {          3: 12.6 }, image: "img/7c649691aa0c4b3d.jpg", name: "PRIVATE SERVICE" }
+    ,299: { rate_base: {          3: 11.4 }, image: "img/9bd44690db5375ac.jpg", name: "secret base ～君がくれたもの～ (10 years after Ver.)" }
+    ,300: { rate_base: {          3: 12.2 }, image: "img/012eb1ed09577836.jpg", name: "No Routine" }
+    ,305: { rate_base: { 2: 11.0, 3: 13.3 }, image: "img/266bd38219201fa1.jpg", name: "幻想のサテライト" }
+    ,306: { rate_base: {          3: 12.2 }, image: "img/106d9eec68ed84b3.jpg", name: "凛として咲く花の如く" }
+    ,307: { rate_base: {          3: 12.7 }, image: "img/ff9f70c8c0d9f24e.jpg", name: "Paqqin" }
+    ,308: { rate_base: {          3: 11.9 }, image: "img/f8d3f2e57ae2ff24.jpg", name: "fake!fake!" }
+    ,309: { rate_base: {          3: 12.5 }, image: "img/cee51d69c428f8f5.jpg", name: "Rising Hope" }
+    ,313: { rate_base: {          3: 11.4 }, image: "img/5ac018495d6f01a5.jpg", name: "ひだまりデイズ" }
+    ,316: { rate_base: {          3: 11.5 }, image: "img/88f9536c08cb4e3f.jpg", name: "みくみくにしてあげる♪【してやんよ】" }
+    ,317: { rate_base: {          3: 13.4 }, image: "img/db15d5b7aefaa672.jpg", name: "Air" }
+    ,318: { rate_base: {          3: 13.1 }, image: "img/f803d578eb4047eb.jpg", name: "DataErr0r" }
+    ,319: { rate_base: {          3: 12.6 }, image: "img/e9eeb98572b140bc.jpg", name: "Say A Vengeance" }
+    ,320: { rate_base: {          3: 12.6 }, image: "img/6b33d4fa539d5adb.jpg", name: "010" }
+    ,321: { rate_base: {          3: 12.5 }, image: "img/40cc7a6a264f88c1.jpg", name: "ERIS -Legend of Gaidelia-" }
+    ,322: { rate_base: {          3: 13.6 }, image: "img/8b145fe4cf0c01bb.jpg", name: "Imperishable Night 2006 (2016 Refine)" }
+    ,323: { rate_base: {          3: 13.5 }, image: "img/282cb1cacd4c1bb4.jpg", name: "Dreadnought" }
+    ,324: { rate_base: {          3: 12.6 }, image: "img/d51d4ffba9f8d45e.jpg", name: "STAGER" }
+    ,325: { rate_base: {          3: 12.6 }, image: "img/97eca622afca0f15.jpg", name: "Her Majesty" }
+    ,326: { rate_base: {          3: 12.5 }, image: "img/fd01fc38e38042e3.jpg", name: "Sakura Fubuki" }
+    ,327: { rate_base: {          3: 12.7 }, image: "img/17c363c1fd2fa7d1.jpg", name: "JULIAN" }
+    ,330: { rate_base: {          3: 12.1 }, image: "img/b3ea0fe012eb7ea2.jpg", name: "ドキドキDREAM!!!" }
+    ,331: { rate_base: {          3: 12.2 }, image: "img/ec37e447b91995dd.jpg", name: "猛進ソリストライフ！" }
+    ,336: { rate_base: {          3: 12.0 }, image: "img/e40fceaa1bb587b7.jpg", name: "シジョウノコエ VOCALO ver." }
+    ,101: { rate_base: {          3: 12.9 }, image: "img/81e347d3b96b2ae1.jpg", name: "Tango Rouge" }
+};
 
 // ---- API wrappers
 
@@ -170,276 +393,29 @@ function dom(template, params)
 // global vars
 // -----------------------------------------------------------------------------
 
-// TODO: No items can be removed from this list. We'd better use hash.
-//
-// List of chart ID vs rate_base, leveled 11 or more
-var chart_list = [
-     { id: 103, level: 2, rate_base: 11.7, image: "img/3210d321c2700a57.jpg", name: "エンドマークに希望と涙を添えて 赤" }
-    ,{ id: 68,  level: 3, rate_base: 11.7, image: "img/145b9b6f4c27d78e.jpg", name: "乗り切れ受験ウォーズ" }
-    ,{ id: 146, level: 3, rate_base: 11.7, image: "img/d3b40f7b8e0758ff.jpg", name: "夕暮れワンルーム" }
-    ,{ id: 69,  level: 2, rate_base: 11.9, image: "img/c2c4ece2034eb620.jpg", name: "The wheel to the right 赤" }
-    ,{ id: 63,  level: 2, rate_base: 11.7, image: "img/2df15f390356067f.jpg", name: "Gate of Fate 赤" }
-    ,{ id: 76,  level: 2, rate_base: 11.8, image: "img/93abb77776c70b47.jpg", name: "luna blu 赤" }
-    ,{ id: 140, level: 3, rate_base: 11.9, image: "img/0aad2e0ff661e7d1.jpg", name: "Guilty" }
-    ,{ id: 75,  level: 3, rate_base: 11.7, image: "img/e1454dc2eeae2030.jpg", name: "Counselor" }
-    ,{ id: 99,  level: 3, rate_base: 11.7, image: "img/ee332e6fa86661fd.jpg", name: "言ノ葉カルマ" }
-    ,{ id: 145, level: 3, rate_base: 11.8, image: "img/0bb58f15b16703ab.jpg", name: "Change Our MIRAI！" }
-    ,{ id: 134, level: 2, rate_base: 11.8, image: "img/08a24ed249ed2eec.jpg", name: "HAELEQUIN (Original Remaster) 赤" }
-    ,{ id: 3,   level: 3, rate_base: 11.8, image: "img/d739ba44da6798a0.jpg", name: "B.B.K.K.B.K.K." }
-    ,{ id: 149, level: 3, rate_base: 11.7, image: "img/c9c2fa20dcd9a46e.jpg", name: "緋色のDance" }
-    ,{ id: 48,  level: 3, rate_base: 11.8, image: "img/b38eba298df2c6db.jpg", name: "Unlimited Spark!" }
-    ,{ id: 96,  level: 3, rate_base: 11.8, image: "img/9d2ebc847487e01b.jpg", name: "チルノのパーフェクトさんすう教室" }
-    ,{ id: 94,  level: 3, rate_base: 12.3, image: "img/164258c65c714d50.jpg", name: "セツナトリップ" }
-    ,{ id: 47,  level: 3, rate_base: 12.0, image: "img/5cb17a59f4b8c133.jpg", name: "六兆年と一夜物語" }
-    ,{ id: 152, level: 2, rate_base: 11.7, image: "img/f63fab30a7b6f160.jpg", name: "Gustav Battle 赤" }
-    ,{ id: 141, level: 2, rate_base: 11.5, image: "img/2e6c11edba79d997.jpg", name: "閃鋼のブリューナク 赤" }
-    ,{ id: 67,  level: 3, rate_base: 11.2, image: "img/11437ebc94947550.jpg", name: "昵懇レファレンス" }
-    ,{ id: 65,  level: 3, rate_base: 11.1, image: "img/713d52aa40ed7fc4.jpg", name: "Anemone" }
-    ,{ id: 163, level: 3, rate_base: 11.3, image: "img/fd6847e3bb2e3629.jpg", name: "幾四音-Ixion-" }
-    ,{ id: 148, level: 3, rate_base: 11.0, image: "img/cd458a75aa049889.jpg", name: "Theme of SeelischTact" }
-    ,{ id: 79,  level: 3, rate_base: 11.0, image: "img/281f821a06a7da18.jpg", name: "ＧＯ！ＧＯ！ラブリズム♥" }
-    ,{ id: 158, level: 3, rate_base: 11.0, image: "img/e3ce6712e8cddf10.jpg", name: "フォルテシモBELL" }
-    ,{ id: 130, level: 3, rate_base: 11.7, image: "img/e4df0d48302ccd26.jpg", name: "スカイクラッドの観測者" }
-    ,{ id: 129, level: 3, rate_base: 11.2, image: "img/f56cd36303a3239a.jpg", name: "Hacking to the Gate" }
-    ,{ id: 176, level: 3, rate_base: 11.3, image: "img/aa0cefb5a0f00457.jpg", name: "Dance!" }
-    ,{ id: 207, level: 3, rate_base: 11.7, image: "img/5151993f923b06a5.jpg", name: "Your Affection (Daisuke Asakura Remix)" }
-    ,{ id: 206, level: 3, rate_base: 11.4, image: "img/e10bbd173df15772.jpg", name: "Signs Of Love (“Never More” ver.)" }
-    ,{ id: 10,  level: 3, rate_base: 11.7, image: "img/0d7bd146ebed6fba.jpg", name: "All I Want" }
-    ,{ id: 204, level: 3, rate_base: 11.0, image: "img/1ea73ffbba6d7ead.jpg", name: "ちくわパフェだよ☆CKP" }
-    ,{ id: 203, level: 3, rate_base: 12.0, image: "img/101d4e7b03a5a89e.jpg", name: "FLOWER" }
-    ,{ id: 91,  level: 3, rate_base: 11.2, image: "img/cb77a66b62023890.jpg", name: "Yet Another ”drizzly rain”" }
-    ,{ id: 115, level: 3, rate_base: 11.5, image: "img/9165ee58223accc0.jpg", name: "Dreaming" }
-    ,{ id: 41,  level: 3, rate_base: 11.6, image: "img/7f17441bc2582ec8.jpg", name: "sweet little sister" }
-    ,{ id: 98,  level: 3, rate_base: 11.4, image: "img/f7e67efaf6ced6ea.jpg", name: "魔理沙は大変なものを盗んでいきました" }
-    ,{ id: 156, level: 3, rate_base: 11.5, image: "img/b33923bd4e6e5609.jpg", name: "FREELY TOMORROW" }
-    ,{ id: 117, level: 3, rate_base: 11.5, image: "img/88124d980ac7eca4.jpg", name: "M.S.S.Planet" }
-    ,{ id: 118, level: 3, rate_base: 12.0, image: "img/17e485acfe11a67f.jpg", name: "腐れ外道とチョコレゐト" }
-    ,{ id: 18,  level: 3, rate_base: 11.2, image: "img/3c2606abe4dded71.jpg", name: "千本桜" }
-    ,{ id: 113, level: 3, rate_base: 11.4, image: "img/3f8eb68a4f6089dc.jpg", name: "ストリーミングハート" }
-    ,{ id: 38,  level: 3, rate_base: 11.0, image: "img/529d98ad07709ae5.jpg", name: "天ノ弱" }
-    ,{ id: 114, level: 3, rate_base: 11.4, image: "img/b02c3912d1524d5c.jpg", name: "Sweet Devil" }
-    ,{ id: 111, level: 3, rate_base: 11.3, image: "img/7ad659a57ef26888.jpg", name: "staple stable" }
-    ,{ id: 110, level: 3, rate_base: 11.2, image: "img/d42200159ef91521.jpg", name: "Magia" }
-    ,{ id: 5,   level: 3, rate_base: 11.3, image: "img/38faf81803b730f3.jpg", name: "Scatman (Ski Ba Bop Ba Dop Bop)" }
-    ,{ id: 60,  level: 3, rate_base: 11.3, image: "img/3bee1cce7d794f31.jpg", name: "only my railgun" }
-    ,{ id: 17,  level: 3, rate_base: 11.1, image: "img/696d4f956ebb4209.jpg", name: "空色デイズ" }
-    ,{ id: 104, level: 3, rate_base: 12.5, image: "img/ff945c9cb9e43e83.jpg", name: "とーきょー全域★アキハバラ？" }
-    ,{ id: 178, level: 3, rate_base: 12.7, image: "img/9f281db3bcc9353b.jpg", name: "stella=steLLa" }
-    ,{ id: 101, level: 3, rate_base: 12.9, image: "img/81e347d3b96b2ae1.jpg", name: "Tango Rouge" }
-    ,{ id: 64,  level: 3, rate_base: 12.7, image: "img/6bf934fede23724d.jpg", name: "今ぞ♡崇め奉れ☆オマエらよ！！～姫の秘メタル渇望～" }
-    ,{ id: 144, level: 3, rate_base: 13.3, image: "img/8b04b9ad2d49850c.jpg", name: "Aragami" }
-    ,{ id: 142, level: 3, rate_base: 12.6, image: "img/a8d181c5442df7d2.jpg", name: "Altale" }
-    ,{ id: 157, level: 3, rate_base: 12.8, image: "img/573109ca9050f55d.jpg", name: "ギガンティック O.T.N" }
-    ,{ id: 154, level: 3, rate_base: 12.7, image: "img/2e9fdbbc15ade5cb.jpg", name: "SAVIOR OF SONG" }
-    ,{ id: 180, level: 2, rate_base: 12.4, image: "img/a732d43fd2a11e8f.jpg", name: "怒槌 赤" }
-    ,{ id: 70,  level: 3, rate_base: 12.4, image: "img/3ccebd87235f591c.jpg", name: "STAR" }
-    ,{ id: 151, level: 3, rate_base: 12.5, image: "img/7237488215dbd1d3.jpg", name: "Alma" }
-    ,{ id: 82,  level: 3, rate_base: 12.5, image: "img/27ef71f8a76f1e8a.jpg", name: "Memories of Sun and Moon" }
-    ,{ id: 108, level: 3, rate_base: 12.0, image: "img/1ec3213366f4ad57.jpg", name: "The ether" }
-    ,{ id: 53,  level: 3, rate_base: 12.3, image: "img/73ad66e81061bba3.jpg", name: "Teriqma" }
-    ,{ id: 95,  level: 3, rate_base: 12.1, image: "img/db38c119e4d8933e.jpg", name: "砂漠のハンティングガール♡" }
-    ,{ id: 51,  level: 3, rate_base: 12.7, image: "img/161f13a787a00032.jpg", name: "My First Phone" }
-    ,{ id: 71,  level: 3, rate_base: 12.3, image: "img/2bf02bef3051ecaf.jpg", name: "Infantoon Fantasy" }
-    ,{ id: 161, level: 3, rate_base: 12.4, image: "img/4ceb5aed4a4a1c47.jpg", name: "私の中の幻想的世界観及びその顕現を想起させたある現実での出来事に関する一考察" }
-    ,{ id: 150, level: 3, rate_base: 11.8, image: "img/2a41ad71b77d12c9.jpg", name: "brilliant better" }
-    ,{ id: 88,  level: 3, rate_base: 12.1, image: "img/c4223e68340efa41.jpg", name: "The Concept of Love" }
-    ,{ id: 6,   level: 3, rate_base: 12.3, image: "img/90589be457544570.jpg", name: "Reach for the Stars" }
-    ,{ id: 136, level: 3, rate_base: 12.5, image: "img/c4f977d264deafb1.jpg", name: "Äventyr" }
-    ,{ id: 128, level: 3, rate_base: 12.7, image: "img/7edc6879319accfd.jpg", name: "The Formula" }
-    ,{ id: 45,  level: 3, rate_base: 12.2, image: "img/90dca26c66c5d5b7.jpg", name: "L9" }
-    ,{ id: 33,  level: 3, rate_base: 13.0, image: "img/fddc37caee47286d.jpg", name: "Blue Noise" }
-    ,{ id: 120, level: 3, rate_base: 12.7, image: "img/a84a31e562efd7a0.jpg", name: "四次元跳躍機関" }
-    ,{ id: 21,  level: 3, rate_base: 11.9, image: "img/4f69fb126f579c2f.jpg", name: "ナイト・オブ・ナイツ" }
-    ,{ id: 132, level: 3, rate_base: 12.2, image: "img/1c508bbd42d335fe.jpg", name: "イカサマライフゲイム" }
-    ,{ id: 83,  level: 3, rate_base: 12.2, image: "img/181682bf5b277726.jpg", name: "ロストワンの号哭" }
-    ,{ id: 27,  level: 3, rate_base: 12.5, image: "img/fdc3bb451f6403d2.jpg", name: "タイガーランペイジ" }
-    ,{ id: 23,  level: 3, rate_base: 12.1, image: "img/b8ab9573859ebe4f.jpg", name: "一触即発☆禅ガール" }
-    ,{ id: 180, level: 3, rate_base: 13.9, image: "img/a732d43fd2a11e8f.jpg", name: "怒槌" }
-    ,{ id: 103, level: 3, rate_base: 13.7, image: "img/3210d321c2700a57.jpg", name: "エンドマークに希望と涙を添えて" }
-    ,{ id: 152, level: 3, rate_base: 13.0, image: "img/f63fab30a7b6f160.jpg", name: "Gustav Battle" }
-    ,{ id: 69,  level: 3, rate_base: 13.3, image: "img/c2c4ece2034eb620.jpg", name: "The wheel to the right" }
-    ,{ id: 63,  level: 3, rate_base: 13.1, image: "img/2df15f390356067f.jpg", name: "Gate of Fate" }
-    ,{ id: 141, level: 3, rate_base: 13.3, image: "img/2e6c11edba79d997.jpg", name: "閃鋼のブリューナク" }
-    ,{ id: 76,  level: 3, rate_base: 13.4, image: "img/93abb77776c70b47.jpg", name: "luna blu" }
-    ,{ id: 107, level: 3, rate_base: 13.0, image: "img/b43fef626f5b88cd.jpg", name: "We Gonna Journey" }
-    ,{ id: 138, level: 3, rate_base: 13.0, image: "img/478e8835e382f740.jpg", name: "conflict" }
-    ,{ id: 135, level: 3, rate_base: 13.5, image: "img/e7ee14d9fe63d072.jpg", name: "Vallista" }
-    ,{ id: 134, level: 3, rate_base: 13.7, image: "img/08a24ed249ed2eec.jpg", name: "HAELEQUIN (Original Remaster)" }
-    ,{ id: 92,  level: 3, rate_base: 12.8, image: "img/17315fb464f265bd.jpg", name: "最終鬼畜妹・一部声" }
-    ,{ id: 159, level: 3, rate_base: 13.3, image: "img/d5a47266b4fe0bfe.jpg", name: "ジングルベル" }
-    ,{ id: 165, level: 3, rate_base: 12.8, image: "img/1e85c4b6775c84b0.jpg", name: "ぼくらの16bit戦争" }
-    ,{ id: 179, level: 3, rate_base: 11.1, image: "img/0e73189a7083e4f4.jpg", name: "すろぉもぉしょん" }
-    ,{ id: 166, level: 3, rate_base: 11.8, image: "img/5a0ac8501e3b95ce.jpg", name: "裏表ラバーズ" }
-    ,{ id: 168, level: 3, rate_base: 11.9, image: "img/1982767436fc52d8.jpg", name: "ネトゲ廃人シュプレヒコール" }
-    ,{ id: 167, level: 3, rate_base: 12.7, image: "img/24611f2e2374e6a8.jpg", name: "脳漿炸裂ガール" }
-    ,{ id: 169, level: 3, rate_base: 11.4, image: "img/f092ddd9e1fe088b.jpg", name: "elegante" }
-    ,{ id: 14,  level: 3, rate_base: 11.0, image: "img/af78dd039a36a4c7.jpg", name: "コネクト" }
-    ,{ id: 235, level: 3, rate_base: 12.5, image: "img/8b84b06033585428.jpg", name: "ファッとして桃源郷" }
-    ,{ id: 232, level: 3, rate_base: 13.4, image: "img/a2069fdb9d860d36.jpg", name: "Elemental Creation" }
-    ,{ id: 205, level: 3, rate_base: 12.7, image: "img/3d7803669dd3fcb9.jpg", name: "SNIPE WHOLE" }
-    ,{ id: 73,  level: 3, rate_base: 12.6, image: "img/0c2791f737ce1ff2.jpg", name: "MUSIC PЯAYER" }
-    ,{ id: 52,  level: 3, rate_base: 13.2, image: "img/a62f975edc860e34.jpg", name: "Cyberozar" }
-    ,{ id: 244, level: 3, rate_base: 12.3, image: "img/e0a700914896ea4a.jpg", name: "回レ！雪月花" }
-    ,{ id: 243, level: 3, rate_base: 12.2, image: "img/8872c759bea3bd9f.jpg", name: "シュガーソングとビターステップ" }
-    ,{ id: 171, level: 3, rate_base: 12.3, image: "img/25abef88cb12af3e.jpg", name: "XL TECHNO" }
-    ,{ id: 232, level: 2, rate_base: 11.3, image: "img/a2069fdb9d860d36.jpg", name: "Elemental Creation 赤" }
-    ,{ id: 52,  level: 2, rate_base: 11.1, image: "img/a62f975edc860e34.jpg", name: "Cyberozar 赤" }
-    ,{ id: 209, level: 3, rate_base: 11.7, image: "img/5744f4cf66710a56.jpg", name: "君色シグナル" }
-    ,{ id: 247, level: 3, rate_base: 11.9, image: "img/58847f9694837c0b.jpg", name: "絶世スターゲイト" }
-    ,{ id: 199, level: 3, rate_base: 12.1, image: "img/d76afb63de1417f8.jpg", name: "ハート・ビート" }
-    ,{ id: 173, level: 3, rate_base: 13.1, image: "img/2e95529be9118a11.jpg", name: "Halcyon" }
-    ,{ id: 185, level: 3, rate_base: 11.2, image: "img/520c1fef62954ca6.jpg", name: "楽園の翼" }
-    ,{ id: 42,  level: 3, rate_base: 11.6, image: "img/4bbc4ec5ee9aa0b6.jpg", name: "oath sign" }
-    ,{ id: 9,   level: 3, rate_base: 11.3, image: "img/fce0bad9123dcd76.jpg", name: "情熱大陸" }
-    ,{ id: 56,  level: 3, rate_base: 11.0, image: "img/2535487ae13b2fd8.jpg", name: "そばかす" }
-    ,{ id: 112, level: 3, rate_base: 11.0, image: "img/3dc05a281c0724f7.jpg", name: "マジLOVE1000%" }
-    ,{ id: 74,  level: 3, rate_base: 11.0, image: "img/feef37ed3d91cfbd.jpg", name: "リリーシア" }
-    ,{ id: 233, level: 3, rate_base: 12.2, image: "img/5fe5db1d2e40ee7a.jpg", name: "アルストロメリア" }
-    ,{ id: 197, level: 3, rate_base: 13.1, image: "img/ae6d3a8806e09613.jpg", name: "Jack-the-Ripper◆" }
-    ,{ id: 226, level: 2, rate_base: 12.3, image: "img/993b5cddb9d9badf.jpg", name: "Garakuta Doll Play 赤" }
-    ,{ id: 226, level: 3, rate_base: 13.8, image: "img/993b5cddb9d9badf.jpg", name: "Garakuta Doll Play" }
-    ,{ id: 62,  level: 3, rate_base: 12.4, image: "img/9386971505bb20b0.jpg", name: "名も無い鳥" }
-    ,{ id: 90,  level: 2, rate_base: 11.6, image: "img/19d57f9a7652308a.jpg", name: "L'épisode 赤" }
-    ,{ id: 90,  level: 3, rate_base: 13.2, image: "img/19d57f9a7652308a.jpg", name: "L'épisode" }
-    ,{ id: 72,  level: 3, rate_base: 13.5, image: "img/ec3a366b4724f8f6.jpg", name: "Genesis" }
-    ,{ id: 197, level: 2, rate_base: 11.2, image: "img/ae6d3a8806e09613.jpg", name: "Jack-the-Ripper◆ 赤" }
-    ,{ id: 255, level: 3, rate_base: 11.1, image: "img/429d34fef5fddb02.jpg", name: "激情！ミルキィ大作戦" }
-    ,{ id: 214, level: 3, rate_base: 11.9, image: "img/f4a2d88c38669f72.jpg", name: "青春はNon-Stop!" }
-    ,{ id: 215, level: 3, rate_base: 12.4, image: "img/81cc90c04676f18b.jpg", name: "Falling Roses" }
-    ,{ id: 200, level: 3, rate_base: 12.1, image: "img/569e7b07c0696bc7.jpg", name: "無敵We are one!!" }
-    ,{ id: 202, level: 2, rate_base: 11.2, image: "img/45112e2818cf80a2.jpg", name: "GEMINI -C- 赤" }
-    ,{ id: 202, level: 3, rate_base: 13.1, image: "img/45112e2818cf80a2.jpg", name: "GEMINI -C-" }
-    ,{ id: 222, level: 3, rate_base: 12.9, image: "img/ad33a423c865bed1.jpg", name: "Mr. Wonderland" }
-    ,{ id: 252, level: 3, rate_base: 12.3, image: "img/bb221e3de960de7d.jpg", name: "愛迷エレジー" }
-    ,{ id: 224, level: 3, rate_base: 11.1, image: "img/b9d170f84c1bb5d3.jpg", name: "恋愛裁判" }
-    ,{ id: 228, level: 3, rate_base: 12.0, image: "img/882be51fe439614d.jpg", name: "このふざけた素晴らしき世界は、僕の為にある" }
-    ,{ id: 213, level: 3, rate_base: 11.9, image: "img/c6d494f528391d1c.jpg", name: "星屑ユートピア" }
-    ,{ id: 212, level: 3, rate_base: 12.1, image: "img/1ee29f73ee8f53d0.jpg", name: "いろは唄" }
-    ,{ id: 131, level: 3, rate_base: 12.6, image: "img/38d3c5a5a45c6d07.jpg", name: "チルドレンレコード" }
-    ,{ id: 220, level: 3, rate_base: 12.3, image: "img/c3041fd82b0a0710.jpg", name: "如月アテンション" }
-    ,{ id: 240, level: 3, rate_base: 12.6, image: "img/47397105bad447fb.jpg", name: "夜咄ディセイブ" }
-    ,{ id: 19,  level: 3, rate_base: 13.2, image: "img/0b98b8b4e7cfd997.jpg", name: "DRAGONLADY" }
-    ,{ id: 106, level: 2, rate_base: 12.2, image: "img/8219519cc94d5524.jpg", name: "宛城、炎上！！ 赤" }
-    ,{ id: 246, level: 3, rate_base: 12.7, image: "img/d445e4878a818d8b.jpg", name: "なるとなぎのパーフェクトロックンロール教室" }
-    ,{ id: 106, level: 3, rate_base: 13.8, image: "img/8219519cc94d5524.jpg", name: "宛城、炎上！！" }
-    ,{ id: 245, level: 3, rate_base: 11.4, image: "img/630ac5b31e8ab816.jpg", name: "Help me, あーりん！" }
-    ,{ id: 61,  level: 3, rate_base: 13.5, image: "img/2ccf97477eaf45ad.jpg", name: "GOLDEN RULE" }
-    ,{ id: 160, level: 3, rate_base: 11.5, image: "img/809bf2b3f8effa6f.jpg", name: "言ノ葉遊戯" }
-    ,{ id: 61,  level: 2, rate_base: 11.0, image: "img/2ccf97477eaf45ad.jpg", name: "GOLDEN RULE 赤" }
-    ,{ id: 196, level: 3, rate_base: 13.7, image: "img/ed40032f25177518.jpg", name: "FREEDOM DiVE" }
-    ,{ id: 196, level: 2, rate_base: 11.9, image: "img/ed40032f25177518.jpg", name: "FREEDOM DiVE 赤" }
-    ,{ id: 121, level: 3, rate_base: 12.5, image: "img/4196f71ce51620a0.jpg", name: "東方妖々夢 ～the maximum moving about～" }
-    ,{ id: 93,  level: 3, rate_base: 12.3, image: "img/6b40809324937ec9.jpg", name: "蒼空に舞え、墨染の桜" }
-    ,{ id: 122, level: 3, rate_base: 12.5, image: "img/67418ba28151c3ff.jpg", name: "少女幻葬戦慄曲　～　Necro Fantasia" }
-    ,{ id: 177, level: 3, rate_base: 12.6, image: "img/6e7843f9d831b0ac.jpg", name: "Jimang Shot" }
-    ,{ id: 36,  level: 3, rate_base: 11.0, image: "img/e273c9d64170b575.jpg", name: "届かない恋 '13" }
-    ,{ id: 126, level: 3, rate_base: 11.3, image: "img/547ba5407b6e7fa0.jpg", name: "Heart To Heart" }
-    ,{ id: 35,  level: 3, rate_base: 12.4, image: "img/aabf49add818546d.jpg", name: "Lapis" }
-    ,{ id: 223, level: 3, rate_base: 13.0, image: "img/8ec9a26e11ec1a40.jpg", name: "カミサマネジマキ" }
-    ,{ id: 216, level: 3, rate_base: 12.3, image: "img/3227722a8345a950.jpg", name: "放課後革命" }
-    ,{ id: 225, level: 3, rate_base: 12.1, image: "img/6f86e2a47e9a283c.jpg", name: "ウミユリ海底譚" }
-    ,{ id: 210, level: 3, rate_base: 12.4, image: "img/040cd43234aed57a.jpg", name: "アスノヨゾラ哨戒班" }
-    ,{ id: 211, level: 3, rate_base: 12.2, image: "img/d99079fecaa936ab.jpg", name: "天樂" }
-    ,{ id: 251, level: 3, rate_base: 12.5, image: "img/457722c9f3ff5473.jpg", name: "Crazy ∞ nighT" }
-    ,{ id: 223, level: 2, rate_base: 11.0, image: "img/8ec9a26e11ec1a40.jpg", name: "カミサマネジマキ 赤" }
-    ,{ id: 217, level: 3, rate_base: 11.8, image: "img/2b3c90b1dab1ecff.jpg", name: "楽園ファンファーレ" }
-    ,{ id: 227, level: 3, rate_base: 11.5, image: "img/74c77deb2f2e5e07.jpg", name: "洗脳" }
-    ,{ id: 208, level: 3, rate_base: 12.7, image: "img/5bab1a38b98d59b5.jpg", name: "SAMBISTA" }
-    ,{ id: 201, level: 2, rate_base: 12.4, image: "img/a251c24a3cc4dbf7.jpg", name: "Contrapasso -inferno- 赤" }
-    ,{ id: 201, level: 3, rate_base: 13.9, image: "img/a251c24a3cc4dbf7.jpg", name: "Contrapasso -inferno-" }
-    ,{ id: 305, level: 3, rate_base: 13.3, image: "img/266bd38219201fa1.jpg", name: "幻想のサテライト" }
-    ,{ id: 317, level: 3, rate_base: 13.4, image: "img/db15d5b7aefaa672.jpg", name: "Air" }
-    ,{ id: 248, level: 3, rate_base: 13.9, image: "img/a2fdef9e4b278a51.jpg", name: "Schrecklicher Aufstand" }
-    ,{ id: 318, level: 3, rate_base: 13.1, image: "img/f803d578eb4047eb.jpg", name: "DataErr0r" }
-    ,{ id: 298, level: 3, rate_base: 12.6, image: "img/7c649691aa0c4b3d.jpg", name: "PRIVATE SERVICE" }
-    ,{ id: 250, level: 3, rate_base: 13.5, image: "img/989f4458fb34aa9d.jpg", name: "Philosopher" }
-    ,{ id: 77,  level: 3, rate_base: 12.8, image: "img/01fc7f761272bfb4.jpg", name: "ケモノガル" }
-    ,{ id: 330, level: 3, rate_base: 12.1, image: "img/b3ea0fe012eb7ea2.jpg", name: "ドキドキDREAM!!!" }
-    ,{ id: 292, level: 3, rate_base: 12.0, image: "img/b12c25f87b1d036e.jpg", name: "月に叢雲華に風" }
-    ,{ id: 306, level: 3, rate_base: 12.2, image: "img/106d9eec68ed84b3.jpg", name: "凛として咲く花の如く" }
-    ,{ id: 124, level: 3, rate_base: 12.5, image: "img/74ce2f0a4b4f6fe2.jpg", name: "夏影" }
-    ,{ id: 309, level: 3, rate_base: 12.5, image: "img/cee51d69c428f8f5.jpg", name: "Rising Hope" }
-    ,{ id: 238, level: 3, rate_base: 11.9, image: "img/4c769ae611f83d21.jpg", name: "フレンズ" }
-    ,{ id: 308, level: 3, rate_base: 11.9, image: "img/f8d3f2e57ae2ff24.jpg", name: "fake!fake!" }
-    ,{ id: 55,  level: 3, rate_base: 11.2, image: "img/506f053a80e1b28e.jpg", name: "夏祭り" }
-    ,{ id: 66,  level: 3, rate_base: 12.3, image: "img/c22702914849a11a.jpg", name: "明るい未来" }
-    ,{ id: 261, level: 3, rate_base: 12.3, image: "img/6e917606db3c5a0e.jpg", name: "ロボットプラネットユートピア" }
-    ,{ id: 102, level: 3, rate_base: 12.5, image: "img/7fc6ae1b488b88de.jpg", name: "Tuning Rangers" }
-    ,{ id: 276, level: 3, rate_base: 12.4, image: "img/82105b37d18450b6.jpg", name: "後夜祭" }
-    ,{ id: 263, level: 3, rate_base: 11.7, image: "img/015358a0c0580022.jpg", name: "Hand in Hand" }
-    ,{ id: 37,  level: 3, rate_base: 11.3, image: "img/335dbb14cedb70bf.jpg", name: "鳥の詩" }
-    ,{ id: 299, level: 3, rate_base: 11.4, image: "img/9bd44690db5375ac.jpg", name: "secret base ～君がくれたもの～ (10 years after Ver.)" }
-    ,{ id: 305, level: 2, rate_base: 11.0, image: "img/266bd38219201fa1.jpg", name: "幻想のサテライト 赤" }
-    ,{ id: 254, level: 3, rate_base: 11.7, image: "img/2e617d713547fe84.jpg", name: "その群青が愛しかったようだった" }
-    ,{ id: 267, level: 3, rate_base: 11.5, image: "img/a0d03551eb3930e9.jpg", name: "心象蜃気楼" }
-    ,{ id: 248, level: 2, rate_base: 12.3, image: "img/a2fdef9e4b278a51.jpg", name: "Schrecklicher Aufstand 赤" }
-    ,{ id: 7,   level: 3, rate_base: 13.6, image: "img/b602913a68fca621.jpg", name: "初音ミクの消失" }
-    ,{ id: 7,   level: 2, rate_base: 12.0, image: "img/b602913a68fca621.jpg", name: "初音ミクの消失　赤" }
-    ,{ id: 287, level: 3, rate_base: 11.9, image: "img/5febf5df2b5094f3.jpg", name: "ロミオとシンデレラ" }
-    ,{ id: 279, level: 3, rate_base: 11.7, image: "img/84ecaebe6bce2a58.jpg", name: "深海少女" }
-    ,{ id: 278, level: 3, rate_base: 11.4, image: "img/5f1d7a520a2735d4.jpg", name: "からくりピエロ" }
-    ,{ id: 286, level: 3, rate_base: 11.5, image: "img/afcce0c85c1f8610.jpg", name: "Tell Your World" }
-    ,{ id: 316, level: 3, rate_base: 11.5, image: "img/88f9536c08cb4e3f.jpg", name: "みくみくにしてあげる♪【してやんよ】" }
-    ,{ id: 288, level: 3, rate_base: 11.6, image: "img/f29f10a963df60cf.jpg", name: "First Twinkle" }
-    ,{ id: 273, level: 3, rate_base: 11.8, image: "img/604157e2c49d91d7.jpg", name: "ビバハピ" }
-    ,{ id: 250, level: 2, rate_base: 11.8, image: "img/989f4458fb34aa9d.jpg", name: "Philosopher 赤" }
-    ,{ id: 336, level: 3, rate_base: 12.0, image: "img/e40fceaa1bb587b7.jpg", name: "シジョウノコエ VOCALO ver." }
-    ,{ id: 319, level: 3, rate_base: 12.6, image: "img/e9eeb98572b140bc.jpg", name: "Say A Vengeance" }
-    ,{ id: 320, level: 3, rate_base: 12.6, image: "img/6b33d4fa539d5adb.jpg", name: "010" }
-    ,{ id: 321, level: 3, rate_base: 12.5, image: "img/40cc7a6a264f88c1.jpg", name: "ERIS -Legend of Gaidelia-" }
-    ,{ id: 137, level: 3, rate_base: 13.6, image: "img/13a5a9ca35a9b71b.jpg", name: "Angel dust" }
-    ,{ id: 187, level: 3, rate_base: 13.2, image: "img/e6642a96885723c1.jpg", name: "患部で止まってすぐ溶ける～狂気の優曇華院" }
-    ,{ id: 322, level: 3, rate_base: 13.6, image: "img/8b145fe4cf0c01bb.jpg", name: "Imperishable Night 2006 (2016 Refine)" }
-    ,{ id: 189, level: 3, rate_base: 12.7, image: "img/9310d07b7e02e73a.jpg", name: "ひれ伏せ愚民どもっ！" }
-    ,{ id: 300, level: 3, rate_base: 12.2, image: "img/012eb1ed09577836.jpg", name: "No Routine" }
-    ,{ id: 190, level: 3, rate_base: 12.6, image: "img/bbaa464731ab96a4.jpg", name: "エテルニタス・ルドロジー" }
-    ,{ id: 331, level: 3, rate_base: 12.2, image: "img/ec37e447b91995dd.jpg", name: "猛進ソリストライフ！" }
-    ,{ id: 259, level: 3, rate_base: 13.1, image: "img/4d66e5d1669d79a2.jpg", name: "Oshama Scramble! (Cranky Remix)" }
-    ,{ id: 230, level: 3, rate_base: 12.4, image: "img/b59d2b2ab877a77d.jpg", name: "Hyperion" }
-    ,{ id: 307, level: 3, rate_base: 12.7, image: "img/ff9f70c8c0d9f24e.jpg", name: "Paqqin" }
-    ,{ id: 229, level: 3, rate_base: 13.4, image: "img/73f86aec8d6c7c9b.jpg", name: "紅華刑" }
-    ,{ id: 262, level: 3, rate_base: 13.6, image: "img/676e59847912f5ca.jpg", name: "Tidal Wave" }
-    ,{ id: 323, level: 3, rate_base: 13.5, image: "img/282cb1cacd4c1bb4.jpg", name: "Dreadnought" }
-    ,{ id: 324, level: 3, rate_base: 12.6, image: "img/d51d4ffba9f8d45e.jpg", name: "STAGER" }
-    ,{ id: 325, level: 3, rate_base: 12.6, image: "img/97eca622afca0f15.jpg", name: "Her Majesty" }
-    ,{ id: 259, level: 2, rate_base: 11.3, image: "img/4d66e5d1669d79a2.jpg", name: "Oshama Scramble! (Cranky Remix) 赤" }
-    ,{ id: 229, level: 2, rate_base: 11.9, image: "img/73f86aec8d6c7c9b.jpg", name: "紅華刑 赤" }
-    ,{ id: 281, level: 3, rate_base: 13.4, image: "img/330e57eeeb0fb2cd.jpg", name: "ラクガキスト" }
-    ,{ id: 293, level: 3, rate_base: 13.2, image: "img/c58227eb0d14938c.jpg", name: "インビジブル" }
-    ,{ id: 270, level: 3, rate_base: 12.3, image: "img/21dfcd3ae2c5c370.jpg", name: "エンヴィキャットウォーク" }
-    ,{ id: 119, level: 3, rate_base: 12.3, image: "img/a7dd6716fcae0cb8.jpg", name: "アウターサイエンス" }
-    ,{ id: 313, level: 3, rate_base: 11.4, image: "img/5ac018495d6f01a5.jpg", name: "ひだまりデイズ" }
-    ,{ id: 296, level: 3, rate_base: 12.1, image: "img/76535cf4c728f2af.jpg", name: "かくしん的☆めたまるふぉ～ぜっ!" }
-    ,{ id: 326, level: 3, rate_base: 12.5, image: "img/fd01fc38e38042e3.jpg", name: "Sakura Fubuki" }
-    ,{ id: 327, level: 3, rate_base: 12.7, image: "img/17c363c1fd2fa7d1.jpg", name: "JULIAN" }
-    ,{ id: 264, level: 3, rate_base: 12.2, image: "img/f44c6b628889f8ec.jpg", name: "My Dearest Song" }
-    ,{ id: 291, level: 3, rate_base: 12.4, image: "img/9c5e71b3588dbc70.jpg", name: "Kronos" }
-];
-
 // latest rate
-var best_rate   = 0;
-var opt_rate    = 0;
-var disp_rate   = 0;
-var recent_rate = 0;
-var worst_chart_rate;
+var disp_rate         = 0;
+var best_rate         = 0;
+var best_list         = new Array();
+var best_rate_border;
+var recent_rate       = 0;
 var recent_candidates = new Array();
-var recent_list = new Array();
+var opt_rate          = 0;
 
 // load the last data from localStorage (if exists)
-var last_cra_version = JSON.parse(localStorage.getItem("cra_version"));
-var last_chart_list  = JSON.parse(localStorage.getItem("cra_chart_list"));
-var last_best_rate   = JSON.parse(localStorage.getItem("cra_best_rate"));
-var last_opt_rate    = JSON.parse(localStorage.getItem("cra_opt_rate"));
-var last_disp_rate   = JSON.parse(localStorage.getItem("cra_disp_rate"));
-var last_recent_rate = JSON.parse(localStorage.getItem("cra_recent_rate"));
+var last_cra_version       = JSON.parse(localStorage.getItem("cra_version"));
+var last_disp_rate         = JSON.parse(localStorage.getItem("cra_disp_rate"));
+var last_best_rate         = JSON.parse(localStorage.getItem("cra_best_rate"));
+var last_best_list         = JSON.parse(localStorage.getItem("cra_best_list"));
+var last_recent_rate       = JSON.parse(localStorage.getItem("cra_recent_rate"));
 var last_recent_candidates = JSON.parse(localStorage.getItem("cra_recent_candidates"));
-var last_recent_list = JSON.parse(localStorage.getItem("cra_recent_list"));
+var last_opt_rate          = JSON.parse(localStorage.getItem("cra_opt_rate"));
 
-// diff between the latest rate and the last rate
-var best_rate_diff;
-var opt_rate_diff;
-var recent_rate_diff;
+// diff between the current rate and the last rate
 var disp_rate_diff;
+var best_rate_diff;
+var recent_rate_diff;
+var opt_rate_diff;
 
 // -----------------------------------------------------------------------------
 // UI
@@ -616,10 +592,6 @@ $("#cra_window_inner")
                     fetch_score_data(2, function() {
                         fetch_score_data(3, function() {
                             fetch_playlog(function () {
-                                localStorage.setItem("cra_chart_list", JSON.stringify(chart_list));
-                                localStorage.setItem("cra_version", JSON.stringify(cra_version));
-                                localStorage.setItem("cra_recent_candidates", JSON.stringify(recent_candidates));
-                                localStorage.setItem("cra_recent_list", JSON.stringify(recent_list));
                                 $("#cra_close_button").show(400);
                                 rate_display();
                             });
@@ -633,10 +605,9 @@ if(cra_version == last_cra_version) {
     $("#cra_window_inner")
         .append($("<h2 id='page_title' class='cra_button cra_view_last'>前回のデータを見る</h2>")
                .click(function() {
-                   chart_list = last_chart_list;
+                   best_list = last_best_list;
                    disp_rate = last_disp_rate;
                    recent_candidates = last_recent_candidates;
-                   recent_list = last_recent_list;
                    rate_display();
                }));
 }
@@ -648,75 +619,76 @@ $("#cra_wrapper").delay(400).fadeIn(400);
 // fetch music / user data
 // -----------------------------------------------------------------------------
 
-// use GetUserPlaylogApi to fetch playlog, and update recent_candidates and recent_list
-function fetch_playlog(callback)
-{
-    function get_recent_list(recent_candidates) {
-        return [].concat(recent_candidates).sort(function (p1, p2) {
-            if (p1.rate !== p2.rate) return p2.rate - p1.rate;
-            else if (p1.play_date < p2.play_date) return -1;
-            else if (p1.play_date > p2.play_date) return 1;
-            return 0;
-        }).slice(0, 10);
+// Create playlog entity if music_info exists. Otherwise return null.
+function playlog(id, level, score, play_date /* optional */) {
+    var music_info = music_info[id];
+    var rate_base  = music_info && music_info.rate_base[id];
+    if (!rate_base) return null;
+    return {
+        id:        id,
+        level:     level,
+        score:     score,
+        rate:      score_to_rate(rate_base, score)
+        play_date: play_date,
+        rate_diff: 0,
+        rate_base: rate_base
+    };
+}
+
+function comp_rate(p1, p2) {
+    if (p1.rate !== p2.rate) return p2.rate - p1.rate;
+    else if (p1.play_date < p2.play_date) return -1;
+    else if (p1.play_date > p2.play_date) return 1;
+    return 0;
+}
+
+function comp_id(p1, p2) {
+    return (p1.id - p2.id) || (p1.level - p2.level);
+}
+
+// push new playlog to recent_candidates if appropriate.
+function push_playlog_to_recent_candidates (playlog) {
+    var recent_list = [].concat(recent_candidates).sort(comp_rate).slice(0, 10);
+    var min_rate    = Math.min.apply(null, recent_list.map(function (p) { return p.rate; }));
+    var min_score   = Math.min.apply(null, recent_list.map(function (p) { return p.score; }));
+
+    if (playlog.length < 30) {
+        recent_candidates.push(playlog);
     }
 
-    function create_playlog(rate_base, score, play_date, id, name, level, image) {
-        return {
-            id: id,
-            level: level,
-            rate_base: rate_base,
-            image: image,
-            name: name,
-            score: score,
-            rate: score_to_rate(rate_base, score),
-            play_date: play_date
-        };
-    }
-
-    $("#cra_window_inner").html("<p>loading playlog ...</p>");
-    request_api("GetUserPlaylogApi", {}, function (d) {
-        recent_candidates = last_recent_candidates || Array.apply(null, new Array(30)).map(function (_) { return create_playlog(0, 0, ""); });
-        var level_name_map = ["basic", "advance", "expert", "master", "worldsend"];
-        var last_play_date = recent_candidates[recent_candidates.length - 1].play_date;
-        for (var i = d.userPlaylogList.length - 1; i >= 0; i--) {
-            if (d.userPlaylogList[i].levelName != "expert" && d.userPlaylogList[i].levelName != "master")
-                continue;
-
-            if (d.userPlaylogList[i].userPlayDate <= last_play_date)
-                continue;
-
-            for (var j = 0; j < chart_list.length; j++) {
-                if (chart_list[j].name == d.userPlaylogList[i].musicName && level_name_map[chart_list[j].level] == d.userPlaylogList[i].levelName) {
-                    var playlog = create_playlog(
-                        chart_list[j].rate_base,
-                        d.userPlaylogList[i].score,
-                        d.userPlaylogList[i].userPlayDate,
-                        chart_list[j].id,
-                        chart_list[j].name,
-                        chart_list[j].level,
-                        chart_list[j].image);
-
-                    recent_list = get_recent_list(recent_candidates);
-
-                    if (playlog.rate > Math.min.apply(null, recent_list.map(function (p) { return p.rate; }))) {
-                        for (var k = 0; k < recent_candidates.length; k++) {
-                            if (recent_candidates[k].rate < playlog.rate) {
-                                recent_candidates.splice(k, 1);
-                                recent_candidates.push(playlog);
-                                break;
-                            }
-                        }
-                    }
-                    else if (playlog.score < 1007500 && playlog.score < Math.min.apply(null, recent_list.map(function (p) { return p.score; }))) {
-                        recent_candidates.shift();
-                        recent_candidates.push(playlog);
-                    }
-                }
+    else if (playlog.rate > min_rate) {
+        for (var k = 0; k < recent_candidates.length; k++) {
+            if (recent_candidates[k].rate < playlog.rate) {
+                recent_candidates.splice(k, 1);
+                recent_candidates.push(playlog);
+                break;
             }
         }
+    }
 
-        recent_list = get_recent_list(recent_candidates);
+    else if (playlog.score < 1007500 && playlog.score < min_score) {
+        recent_candidates.shift();
+        recent_candidates.push(playlog);
+    }
+}
 
+// use GetUserPlaylogApi to fetch playlog, and update
+// recent_candidates and recent_list.
+function fetch_playlog(callback)
+{
+    $("#cra_window_inner").html("<p>loading playlog ...</p>");
+    request_api("GetUserPlaylogApi", {}, function (d) {
+        var last_play_date = recent_candidates[recent_candidates.length - 1].play_date;
+        for (var i = d.userPlaylogList.length - 1; i >= 0; i--) {
+            var playlog = playlog(
+                d.userPlaylogList[i].musicId,
+                level_name_map[d.userPlaylogList[i].levelName],
+                d.userPlaylogList[i].score,
+                d.userPlaylogList[i].userPlayDate,
+            );
+            if (playlog && playlog.play_date > last_play_date)
+                push_playlog_to_recent_candidates(playlog);
+        }
         callback();
     }, function () {
         $("#cra_window_inner").html("<p>CHUNITHM NET との通信に失敗しました。</p>");
@@ -730,14 +702,13 @@ function fetch_score_data(level, callback)
     request_api("GetUserMusicApi", {
         level: "1990" + level
     }, function(d) {
-        var map = {};
-        for (var i = 0; i < d.userMusicList.length; i++)
-            map[d.userMusicList[i].musicId] = d.userMusicList[i].scoreMax;
-        for (var i = 0; i < chart_list.length; i++) {
-            if (chart_list[i].level == level) {
-                chart_list[i].score = map[chart_list[i].id] || 0;
-                chart_list[i].rate  = score_to_rate(chart_list[i].rate_base, chart_list[i].score);
-            }
+        for (var i = 0; i < d.userMusicList.length; i++) {
+            var playlog = playlog(
+                d.userMusicList[i].musicId,
+                level,
+                d.userMusicList[i].scoreMax
+            );
+            if (playlog) best_list.push(playlog);
         }
         callback();
     }, function() {
@@ -753,7 +724,6 @@ function fetch_user_data(callback)
         friendCode: 0, fileLevel: 1
     }, function(d) {
         disp_rate = d.userInfo.playerRating / 100.0;
-        localStorage.setItem("cra_disp_rate", JSON.stringify(disp_rate));
         callback();
     }, function() {
         $("#cra_window_inner")
@@ -1062,19 +1032,33 @@ function rate_display()
 {
     var i;
 
-    $("#cra_window_inner").html("<p>calculating rate ...</p>");
+    $("#cra_window_inner").html("<p>computing rate ...</p>");
+
+    // save lists to localstorage (before they get sorted)
+    localStorage.setItem("cra_version", JSON.stringify(cra_version));
+    localStorage.setItem("cra_best_list", JSON.stringify(best_list));
+    localStorage.setItem("cra_recent_candidates", JSON.stringify(recent_candidates));
+    localStorage.setItem("cra_recent_list", JSON.stringify(recent_list));
 
     // calculate score improvement
-    for (i = 0; i < chart_list.length; i++) {
-        chart_list[i].rate_diff =
-            !last_chart_list ? 0
-            : chart_list[i].rate - (last_chart_list[i] && last_chart_list[i].rate || 0);
+    best_list      = best_list.sort(comp_id);
+    last_best_list = last_best_list && last_best_list.sort(comp_id);
+    for (var i = 0, j = 0; i < best_list.length;) {
+        if (!last_best_list[j]) break;
+        var comp = comp_rate(best_list[i], last_best_list[j]);
+        if (comp < 0) j++;
+        else if (comp > 0) i++;
+        else {
+            best_list[i].rate_diff = best_list[i].rate - last_best_list[j].rate;
+            i++;
+            j++;
+        }
     }
 
     // calculate rate and their diff
-    chart_list.sort(function(a, b) { return - (a.rate - b.rate); });
-    for (i = 0; i < 30; i++) best_rate += chart_list[i].rate;
-    opt_rate = ((best_rate + chart_list[0].rate * 10) / 40);
+    best_list.sort(function(a, b) { return - (a.rate - b.rate); });
+    for (i = 0; i < 30; i++) best_rate += best_list[i].rate;
+    opt_rate = ((best_rate + best_list[0].rate * 10) / 40);
     best_rate = (best_rate / 30);
     recent_rate = disp_rate * 4 - best_rate * 3;
     best_rate_diff = last_best_rate ? best_rate - last_best_rate : 0;
@@ -1082,27 +1066,28 @@ function rate_display()
     disp_rate_diff = last_disp_rate ? disp_rate - last_disp_rate : 0;
     recent_rate_diff = last_recent_rate ? recent_rate - last_recent_rate : 0;
 
-    // save rate to localstorage
+    // save rates to localStorage
+    localStorage.setItem("cra_disp_rate", JSON.stringify(disp_rate));
     localStorage.setItem("cra_best_rate", JSON.stringify(best_rate));
     localStorage.setItem("cra_opt_rate", JSON.stringify(opt_rate));
     localStorage.setItem("cra_recent_rate", JSON.stringify(recent_rate));
 
     // calculate required score to improve the rate
-    worst_chart_rate = chart_list[29].rate;
-    for (i = 0; i < chart_list.length; i++)
+    best_rate_border = best_list[Math.min(29, best_list.length - 1)].rate;
+    for (i = 0; i < best_list.length; i++)
     {
-        chart_list[i].req_score = rate_to_score(chart_list[i].rate_base, worst_chart_rate);
-        chart_list[i].req_diff = Math.max(chart_list[i].req_score - chart_list[i].score, 0);
+        best_list[i].req_score = rate_to_score(best_list[i].rate_base, best_rate_border);
+        best_list[i].req_diff = Math.max(best_list[i].req_score - best_list[i].score, 0);
     }
 
     // calculate recommendability
     var block_ix = Math.max(0, Math.min(21, Math.ceil(best_rate * 10 - 130)));
-    for (i = 0; i < chart_list.length; i++) {
+    for (i = 0; i < best_list.length; i++) {
         var rate = expected_rate[block_ix][i];
-        chart_list[i].expected_improvement =
-              chart_list[i].rate >= rate || rate <= worst_chart_rate ? 0
-            : i < 30 ? rate - chart_list[i].rate
-            : rate - worst_chart_rate;
+        best_list[i].expected_improvement =
+              best_list[i].rate >= rate || rate <= best_rate_border ? 0
+            : i < 30 ? rate - best_list[i].rate
+            : rate - best_rate_border;
     }
 
     // remove window and show the result
@@ -1144,8 +1129,8 @@ function rate_display()
                   "(B: " + rate_str(best_rate) + rate_diff_str(best_rate_diff) + " + " +
                   "R: " + rate_str(recent_rate) + rate_diff_str(recent_rate_diff) + ") / " +
                   "最大レート: " + rate_str(opt_rate) + rate_diff_str(opt_rate_diff) + " / " +
-                  "曲別レートトップ: " + rate_str(chart_list[0].rate) +
-                  " (" + chart_list[0].name + ") #CHUNITHMRateAnalyzer")
+                  "曲別レートトップ: " + rate_str(best_list[0].rate) +
+                  " (" + best_list[0].name + ") #CHUNITHMRateAnalyzer")
             .html("Tweet");
 
         $("#cra_sort_menu")
@@ -1166,68 +1151,65 @@ function rate_display()
             .html("Follow");
 
         $("#cra_sort_rate").click(function() {
-            chart_list.sort(function(a, b) { return - (a.rate - b.rate); });
-            render_chart_list({ 0: "曲別レート (高い順)", 30: "BEST 枠ここまで" });
+            best_list.sort(comp_rate);
+            render_chart_list(best_list, { 0: "曲別レート (高い順)", 30: "BEST 枠ここまで" });
         });
 
         $("#cra_sort_base").click(function() {
-            chart_list.sort(function(a, b) { return - (a.rate_base - b.rate_base); });
+            best_list.sort(function(a, b) { return - (a.rate_base - b.rate_base); });
             var indices = { 0 : "LEVEL 13+" };
-            for (i = 0; chart_list[i].rate_base >= 13.7; i++) ;
+            for (i = 0; best_list[i].rate_base >= 13.7; i++) ;
             indices[i] = "LEVEL 13";
-            for (i = 0; chart_list[i].rate_base >= 13; i++) ;
+            for (i = 0; best_list[i].rate_base >= 13; i++) ;
             indices[i] = "LEVEL 12+";
-            for (i = 0; chart_list[i].rate_base >= 12.7; i++) ;
+            for (i = 0; best_list[i].rate_base >= 12.7; i++) ;
             indices[i] = "LEVEL 12";
-            for (i = 0; chart_list[i].rate_base >= 12; i++) ;
+            for (i = 0; best_list[i].rate_base >= 12; i++) ;
             indices[i] = "LEVEL 11";
-            render_chart_list(indices);
+            render_chart_list(best_list, indices);
         });
 
         $("#cra_sort_score").click(function() {
-            chart_list.sort(function(a, b) { return - (a.score - b.score) });
+            best_list.sort(function(a, b) { return - (a.score - b.score) });
             var indices = { 0 : "SSS" };
-            for (i = 0; chart_list[i].score >= 1007500; i++) ;
+            for (i = 0; best_list[i].score >= 1007500; i++) ;
             indices[i] = "SS";
-            for (i = 0; chart_list[i].score >= 1000000; i++) ;
+            for (i = 0; best_list[i].score >= 1000000; i++) ;
             indices[i] = "S";
-            for (i = 0; chart_list[i].score >=  975000; i++) ;
+            for (i = 0; best_list[i].score >=  975000; i++) ;
             indices[i] = "AAA";
-            for (i = 0; chart_list[i].score >=  950000; i++) ;
+            for (i = 0; best_list[i].score >=  950000; i++) ;
             indices[i] = "AA";
-            for (i = 0; chart_list[i].score >=  925000; i++) ;
+            for (i = 0; best_list[i].score >=  925000; i++) ;
             indices[i] = "A";
-            for (i = 0; chart_list[i].score >=  900000; i++) ;
+            for (i = 0; best_list[i].score >=  900000; i++) ;
             indices[i] = "A未満"
-            render_chart_list(indices);
+            render_chart_list(best_list, indices);
         });
 
         $("#cra_sort_score_req").click(function() {
-            chart_list.sort(function(a, b) {
+            best_list.sort(function(a, b) {
                 return (isNaN(b.req_diff) ? -1 : 0) + (isNaN(b.req_diff) ? 1 : 0)
                     || a.req_diff - b.req_diff
                     || - (a.rate_base - b.rate_base);
             });
-            render_chart_list({ 0: "レート上げに必要なスコア順", 30: "BEST 枠ここまで" });
+            render_chart_list(best_list, { 0: "レート上げに必要なスコア順", 30: "BEST 枠ここまで" });
         });
 
         $("#cra_sort_score_ave").click(function() {
             var indices = { };
-            chart_list.sort(function(a, b) {
+            best_list.sort(function(a, b) {
                     return - (a.expected_improvement - b.expected_improvement)
             });
-            for (var i = 0; i < chart_list.length && chart_list[i].expected_improvement > 0; i++) ;
+            for (var i = 0; i < best_list.length && best_list[i].expected_improvement > 0; i++) ;
             indices[0] = "おすすめ"
             indices[i] = "おすすめここまで"
-            render_chart_list(indices);
+            render_chart_list(best_list, indices);
         });
 
         $("#cra_recent_list").click(function () {
-            var indeices1 = { };
-            var indeices2 = { };
-            indeices1[0] = "Recent枠";
-            indeices2[0] = "Recent候補枠";
-            render_recent_list(indeices1, indeices2);
+            recent_candidates.sort(comp_rate);
+            render_chart_list(recent_candidates, { 0: 'Recent枠', 10: 'Recent候補枠'});
         });
 
         $("#cra_manage_play_data").click(function () {
@@ -1261,47 +1243,50 @@ function rate_display()
 
         // render chart list
         var indices = {};
-        chart_list.sort(function(a, b) {
+        best_list.sort(function(a, b) {
             return (a.rate_diff ? 0 : 1) + (b.rate_diff ? 0 : -1) || - (a.rate - b.rate);
         });
-        for (var i = 0; i < chart_list.length && chart_list[i].rate_diff != 0; i++) ;
+        for (var i = 0; i < best_list.length && best_list[i].rate_diff != 0; i++);
         if (i) indices[0] = "最近レートを更新した曲";
         indices[i] = "曲別レート (高い順)";
-        for (; i < chart_list.length && chart_list[i].req_diff <= 0; i++) ;
+        for (; i < best_list.length && best_list[i].req_diff <= 0; i++) ;
         indices[i] = "BEST 枠ここまで";
-        render_chart_list(indices);
+        render_chart_list(best_list, indices);
     });
 }
 
 // refresh the chart list display
-function render_chart_list(msgs)
+function render_chart_list(list, msgs)
 {
     // hide old items
     $("#cra_chart_list *").remove();
     $("#cra_chart_list").css({ display: "none" });
 
-    for (var i = 0; i < chart_list.length; i++)
+    for (var i = 0; i < list.length; i++)
     {
         if (msgs[i])
             $("#cra_chart_list")
             .append("<hr>")
             .append(dom(["div", {class: "mt_15"}, ["h2#page_title", msgs[i]]]));
 
-        if (isNaN(chart_list[i].req_diff))
-            continue;
+        // 満点出しても BEST 枠を改善できない譜面を出さない（Recent 枠
+        // の場合は req_diff = undefined なので影響しない）
+        if (isNaN(list[i].req_diff)) continue;
 
-        var difficulty_icon = chart_list[i].level == 2 ? "common/images/icon_expert.png"
+        var difficulty_icon = list[i].level == 2 ? "common/images/icon_expert.png"
             : "common/images/icon_master.png";
 
         var $list_item = $("<div class='frame02 w400 cra_chart_list_item'>")
             .appendTo("#cra_chart_list");
+
+        var music_info = music_info[list[i].id];
 
         $list_item
             .html(`
 <div class="play_jacket_side">
   <div class="play_jacket_area">
     <div id="Jacket" class="play_jacket_img">
-      <img src=${chart_list[i].image}>
+      <img src=${music_info.image}>
     </div>
   </div>
 </div>
@@ -1311,29 +1296,29 @@ function render_chart_list(msgs)
       <img src="${difficulty_icon}">
     </div>
     <div id="Track" class="play_track_text">
-      ${rate_str(chart_list[i].rate_base)}
+      ${rate_str(list[i].rate_base)}
     </div>
   </div>
   <div class="box02 play_musicdata_block">
     <div id="MusicTitle" class="play_musicdata_title">
-      ${chart_list[i].name}
+      ${music_info.name}
     </div>
     <div class="play_musicdata_score clearfix">
       <div class="play_musicdata_score_text">
-        Score：<span id="Score">${chart_list[i].score}</span>
+        Score：<span id="Score">${list[i].score}</span>
       </div>
       <br>
       <div class="play_musicdata_score_text">
         Rate：
         <span id="Rate">
-          ${rate_str(chart_list[i].rate)}${rate_diff_str(chart_list[i].rate_diff)}
+          ${rate_str(list[i].rate)}${rate_diff_str(list[i].rate_diff)}
         </span>
       </div>
     </div>
   </div>
   <div id="IconBatch" class="play_musicdata_icon clearfix">
-    ${chart_list[i].req_diff > 0 ?
-      "BEST枠入りまで: " + chart_list[i].req_diff + " (" + chart_list[i].req_score + ")" :
+    ${list[i].req_diff > 0 ?
+      "BEST枠入りまで: " + list[i].req_diff + " (" + list[i].req_score + ")" :
       ""}
   </div>
 </div>`);
@@ -1350,122 +1335,5 @@ function render_chart_list(msgs)
     }
 
     // $("#cra_chart_list").show(400);
-    $("#cra_chart_list").show();
-}
-
-// refresh the recent list display
-function render_recent_list(msgs1, msgs2)
-{
-    // hide old items
-    $("#cra_chart_list *").remove();
-    $("#cra_chart_list").css({ display: "none" });
-
-    for (var i = 0; i < recent_list.length; i++) {
-        if (msgs1[i])
-            $("#cra_chart_list")
-                .append("<hr>")
-                .append(dom(["div", { class: "mt_15" }, ["h2#page_title", msgs1[i]]]));
-
-        if (!recent_list[i].id || isNaN(recent_list[i].id))
-            continue;
-
-        var difficulty_icon = recent_list[i].level == 2 ? "common/images/icon_expert.png"
-            : "common/images/icon_master.png";
-
-        var $list_item = $("<div class='frame02 w400 cra_chart_list_item'>")
-            .appendTo("#cra_chart_list");
-
-        $list_item
-            .html(`
-<div class="play_jacket_side">
-  <div class="play_jacket_area">
-    <div id="Jacket" class="play_jacket_img">
-      <img src=${recent_list[i].image}>
-    </div>
-  </div>
-</div>
-<div class="play_data_side01">
-  <div class="box02 play_track_block">
-    <div id="TrackLevel" class="play_track_result">
-      <img src="${difficulty_icon}">
-    </div>
-    <div id="Track" class="play_track_text">
-      ${rate_str(recent_list[i].rate_base)}
-    </div>
-  </div>
-  <div class="box02 play_musicdata_block">
-    <div id="MusicTitle" class="play_musicdata_title">
-      ${recent_list[i].name}
-    </div>
-    <div class="play_musicdata_score clearfix">
-      <div class="play_musicdata_score_text">
-        Score：<span id="Score">${recent_list[i].score}</span>
-      </div>
-      <br>
-      <div class="play_musicdata_score_text">
-        Rate：
-        <span id="Rate">
-          ${rate_str(recent_list[i].rate)}
-        </span>
-      </div>
-    </div>
-  </div>
-</div>`);
-    }
-
-    for (var i = 0; i < recent_candidates.length; i++) {
-        var index = recent_candidates.length - (i + 1);
-        if (msgs2[i])
-            $("#cra_chart_list")
-                .append("<hr>")
-                .append(dom(["div", { class: "mt_15" }, ["h2#page_title", msgs2[i]]]));
-
-        if (!recent_candidates[index].id || isNaN(recent_candidates[index].id))
-            continue;
-
-        var difficulty_icon = recent_candidates[index].level == 2 ? "common/images/icon_expert.png"
-            : "common/images/icon_master.png";
-
-        var $list_item = $("<div class='frame02 w400 cra_chart_list_item'>")
-            .appendTo("#cra_chart_list");
-
-        $list_item
-            .html(`
-<div class="play_jacket_side">
-  <div class="play_jacket_area">
-    <div id="Jacket" class="play_jacket_img">
-      <img src=${recent_candidates[index].image}>
-    </div>
-  </div>
-</div>
-<div class="play_data_side01">
-  <div class="box02 play_track_block">
-    <div id="TrackLevel" class="play_track_result">
-      <img src="${difficulty_icon}">
-    </div>
-    <div id="Track" class="play_track_text">
-      ${rate_str(recent_candidates[index].rate_base)}
-    </div>
-  </div>
-  <div class="box02 play_musicdata_block">
-    <div id="MusicTitle" class="play_musicdata_title">
-      ${recent_candidates[index].name}
-    </div>
-    <div class="play_musicdata_score clearfix">
-      <div class="play_musicdata_score_text">
-        Score：<span id="Score">${recent_candidates[index].score}</span>
-      </div>
-      <br>
-      <div class="play_musicdata_score_text">
-        Rate：
-        <span id="Rate">
-          ${rate_str(recent_candidates[index].rate)}
-        </span>
-      </div>
-    </div>
-  </div>
-</div>`);
-    }
-
     $("#cra_chart_list").show();
 }

--- a/chunithm.js
+++ b/chunithm.js
@@ -1,7 +1,7 @@
 // CHUNITHM Rate Analyzer (C) zk_phi 2015-
 
 // ※ localStorage のデータに互換性がなくなる場合は必ずバージョンを上げる
-var cra_version = 161224;
+var CRA_VERSION = 161224;
 
 if (!location.href.match(/^https:\/\/chunithm-net.com/)) {
     alert("CHUNITHM NET を開いているタブで実行してください。");
@@ -16,7 +16,7 @@ if (!location.href.match(/^https:\/\/chunithm-net.com/)) {
 
 // list of resources required to execute this script (note that all
 // resources must be provided via HTTPS)
-var dependencies = [
+var DEPENDENCIES = [
     "https://platform.twitter.com/widgets.js" // Twitter tweet/follow button
 ];
 
@@ -26,9 +26,9 @@ var dependencies = [
 
 // ---- constants
 
-var level_name_map = { basic: 0, advance: 1, expert: 2, master: 3, worldsend: 4 };
+var LEVEL_ID = { basic: 0, advance: 1, expert: 2, master: 3, worldsend: 4 };
 
-var music_info = {
+var MUSIC_INFO = {
      003: { rate_base: {          3: 11.8 }, image: "img/d739ba44da6798a0.jpg", name: "B.B.K.K.B.K.K." }
     ,005: { rate_base: {          3: 11.3 }, image: "img/38faf81803b730f3.jpg", name: "Scatman (Ski Ba Bop Ba Dop Bop)" }
     ,006: { rate_base: {          3: 12.3 }, image: "img/90589be457544570.jpg", name: "Reach for the Stars" }
@@ -555,7 +555,7 @@ var the_css = {
 
 // ---- load the dependencies and the CSS
 
-dependencies.map(function(x) { $("head").append("<script src='" + x + "'>"); });
+DEPENDENCIES.map(function(x) { $("head").append("<script src='" + x + "'>"); });
 $chunithm_net.fadeTo(400, 0.75);
 $("head").append("<style>" + _css(the_css) + "</style>");
 
@@ -608,7 +608,7 @@ $("#cra_window_inner")
            }));
 
 // view button
-if(cra_version == last_cra_version) {
+if(CRA_VERSION == last_cra_version) {
     $("#cra_window_inner")
         .append($("<h2 id='page_title' class='cra_button cra_view_last'>前回のデータを見る</h2>")
                .click(function() {
@@ -625,9 +625,9 @@ $("#cra_wrapper").delay(400).fadeIn(400);
 // fetch music / user data
 // -----------------------------------------------------------------------------
 
-// Create playlog entity if music_info exists. Otherwise return null.
+// Create playlog entity if MUSIC_INFO exists. Otherwise return null.
 function playlog(id, level, score, play_date /* optional */) {
-    var info = music_info[id];
+    var info = MUSIC_INFO[id];
     var rate_base  = info && info.rate_base[level];
     if (!rate_base) return null;
     return {
@@ -685,7 +685,7 @@ function fetch_playlog(callback)
         for (var i = d.userPlaylogList.length - 1; i >= 0; i--) {
             var log = playlog(
                 d.userPlaylogList[i].musicId,
-                level_name_map[d.userPlaylogList[i].levelName],
+                LEVEL_ID[d.userPlaylogList[i].levelName],
                 d.userPlaylogList[i].score,
                 d.userPlaylogList[i].userPlayDate
             );
@@ -1038,7 +1038,7 @@ function rate_display()
     $("#cra_window_inner").html("<p>computing rate ...</p>");
 
     // save lists to localstorage (before they get sorted)
-    localStorage.setItem("cra_version", JSON.stringify(cra_version));
+    localStorage.setItem("cra_version", JSON.stringify(CRA_VERSION));
     localStorage.setItem("cra_best_list", JSON.stringify(best_list));
     localStorage.setItem("cra_recent_candidates", JSON.stringify(recent_candidates));
 
@@ -1281,7 +1281,7 @@ function render_chart_list(list, msgs)
         var $list_item = $("<div class='frame02 w400 cra_chart_list_item'>")
             .appendTo("#cra_chart_list");
 
-        var info = music_info[list[i].id];
+        var info = MUSIC_INFO[list[i].id];
 
         $list_item
             .html(`

--- a/chunithm.js
+++ b/chunithm.js
@@ -587,6 +587,7 @@ $("#cra_window_outer")
     .html("<div id='cra_window_inner' class='frame01_inside w450'></div>");
 $("#cra_window_inner")
     .html("<p class='cra_caution'>CAUTION</p>" +
+          "<p>12/3- Recent枠表示機能(β)とデータ提供機能の追加。</p>" +
           "<p>9/13- スコアの取得を高速化。</p>" +
           "<p>9/12- 単曲レートの切り捨て位置を修正。</p>" +
           "<p>8/29- 譜面定数の判明したものから更新しています (譜面定数の調査方法は<a href='http://d.hatena.ne.jp/risette14/20150924/1443064402'>こちら</a>)。</p>" +

--- a/chunithm.js
+++ b/chunithm.js
@@ -653,10 +653,9 @@ function fetch_playlog(callback)
 {
     function get_recent_list(recent_candidates) {
         return [].concat(recent_candidates).sort(function (p1, p2) {
-            if (p1.rate > p2.rate) return 1;
-            else if (p1.rate < p2.rate) return -1;
-            else if (p1.play_date > p2.play_date) return -1;
-            else if (p1.play_date < p2.play_date) return 1;
+            if (p1.rate !== p2.rate) return p2.rate - p1.rate;
+            else if (p1.play_date < p2.play_date) return -1;
+            else if (p1.play_date > p2.play_date) return 1;
             return 0;
         }).slice(0, 10);
     }

--- a/chunithm.js
+++ b/chunithm.js
@@ -1285,7 +1285,7 @@ function render_chart_list(list, msgs)
 
         // 満点出しても BEST 枠を改善できない譜面を出さない（Recent 枠
         // の場合は req_diff = undefined なので影響しない）
-        if (list[i].req_diff && isNaN(list[i].req_diff)) continue;
+        if (list[i].req_diff != undefined && isNaN(list[i].req_diff)) continue;
 
         var difficulty_icon = list[i].level == 2 ? "common/images/icon_expert.png"
             : "common/images/icon_master.png";


### PR DESCRIPTION
#36 の対応です。
Recent枠表示機能(β)とデータ提供機能を実装しました。

【Recent枠表示機能(β)について】
・クライアント内で閉じた機能です。
・各種通信APIを呼び出すところでプレイ履歴取得APIを呼び出す必要があります。
・Recent枠が単曲レート値降順で表示され、その下にRecent候補枠がプレイ日時降順で表示されます。

【データ提供機能について】
・サーバーと通信する機能です。
・実行するとユーザー情報やレコード、プレイ履歴等の情報を取得して、GASにデータを送ります。
・サーバー側でシミュレートしたRecent候補枠とRecent枠の結果が渡され、アラートで表示されます。
・クライアント側の処理はフォークした私のリポジトリ内に配置されています。

ご確認の程、よろしくお願いします。